### PR TITLE
Remove `k`, `ρ`, and `Cₚ` from `AbstractThermoParams`

### DIFF
--- a/src/AsteroidThermoPhysicalModels.jl
+++ b/src/AsteroidThermoPhysicalModels.jl
@@ -23,13 +23,13 @@ export RYUGU, DIDYMOS, DIMORPHOS
 include("obj.jl")
 include("shape.jl")
 include("facet.jl")
-export ShapeModel
+export ShapeModel, load_shape_obj
 
 include("thermophysics.jl")
 include("TPM.jl")
 include("energy_flux.jl")
 include("non_grav.jl")
-export init_temperature!, run_TPM!
+export thermal_skin_depth, thermal_inertia, init_temperature!, run_TPM!
 
 include("roughness.jl")
 

--- a/src/non_grav.jl
+++ b/src/non_grav.jl
@@ -24,7 +24,7 @@ function update_thermal_force!(shape, A_B, ε, nₜ)
         F_scat = shape.flux[i, 2]
         Tᵢ = shape.temperature[begin, i, nₜ]
 
-        ## Total amount of scattered light and radiation [W/m²].
+        ## Total amount of scattered light and radiation, Eᵢ [W/m²].
         ## Note that both are assumed to be isotropic.
         A_B = (A_B isa Real ? A_B : A_B[i])
         ε = (ε isa Real ? ε : ε[i])

--- a/src/thermophysics.jl
+++ b/src/thermophysics.jl
@@ -5,7 +5,6 @@
 # ****************************************************************
 
 """
-    thermal_skin_depth(params)      -> l_2π
     thermal_skin_depth(P, k, ρ, Cp) -> l_2π
 
 # Arguments
@@ -21,7 +20,6 @@ thermal_skin_depth(P, k, ρ, Cₚ) = @. √(4π * P * k / (ρ * Cₚ))
 
 
 """
-    thermal_inertia(params)   -> Γ
     thermal_inertia(k, ρ, Cp) -> Γ
 
 # Arguments
@@ -234,18 +232,18 @@ Update surface temperature under radiative boundary condition using Newton's met
 - `nₜ`     : Index of the current time step
 """
 function update_surface_temperature!(shape::ShapeModel, params::AbstractThermoParams, nₜ::Integer)
-    for i in eachindex(shape.faces)
+    for nₛ in eachindex(shape.faces)
         P    = params.P
-        l    = (params.l    isa Real ? params.l    : params.l[i]   )
-        Γ    = (params.Γ    isa Real ? params.Γ    : params.Γ[i]   )
-        A_B  = (params.A_B  isa Real ? params.A_B  : params.A_B[i] )
-        A_TH = (params.A_TH isa Real ? params.A_TH : params.A_TH[i])
-        ε    = (params.ε    isa Real ? params.ε    : params.ε[i]   )
+        l    = (params.l    isa Real ? params.l    : params.l[nₛ]   )
+        Γ    = (params.Γ    isa Real ? params.Γ    : params.Γ[nₛ]   )
+        A_B  = (params.A_B  isa Real ? params.A_B  : params.A_B[nₛ] )
+        A_TH = (params.A_TH isa Real ? params.A_TH : params.A_TH[nₛ])
+        ε    = (params.ε    isa Real ? params.ε    : params.ε[nₛ]   )
         Δz   = params.Δz
 
-        F_sun, F_scat, F_rad = shape.flux[i, :]
+        F_sun, F_scat, F_rad = shape.flux[nₛ, :]
         F_total = total_flux(A_B, A_TH, F_sun, F_scat, F_rad)
-        update_surface_temperature!((@views shape.temperature[:, i, nₜ]), F_total, P, l, Γ, ε, Δz)  # Δz should be normalized by l
+        update_surface_temperature!((@views shape.temperature[:, nₛ, nₜ]), F_total, P, l, Γ, ε, Δz)  # Δz should be normalized by l
     end
 end
 
@@ -290,8 +288,8 @@ end
 Update bottom temperature under boundary condition of insulation
 """
 function update_bottom_temperature!(shape::ShapeModel, nₜ::Integer)
-    for i in eachindex(shape.faces)
-        shape.temperature[end, i, nₜ] = shape.temperature[end-1, i, nₜ]
+    for nₛ in eachindex(shape.faces)
+        shape.temperature[end, nₛ, nₜ] = shape.temperature[end-1, nₛ, nₜ]
     end
 end
 

--- a/src/thermophysics.jl
+++ b/src/thermophysics.jl
@@ -232,10 +232,6 @@ Update surface temperature under radiative boundary condition using Newton's met
 - `shape`  : Shape model (`ShapeModel`)
 - `params` : Thermophysical prameters
 - `nₜ`     : Index of the current time step
-
-In the normalized equation of the surface boundary condition,
-the coefficient `Γ / √(4π * P)` is equivalent for `k / l`,
-where `Γ` is the thermal inertia and `P` the rotation period.
 """
 function update_surface_temperature!(shape::ShapeModel, params::AbstractThermoParams, nₜ::Integer)
     for i in eachindex(shape.faces)
@@ -258,13 +254,14 @@ end
 """
     update_surface_temperature!(T::AbstractVector, F_total::Real, k::Real, l::Real, Δz::Real, ε::Real)
 
-Newton's method to update the surface temperature under radiative boundary condition
+Newton's method to update the surface temperature under radiative boundary condition.
+The length in this equation is normalized by thermal skin depth `l`.
 
 # Arguments
 - `T`       : 1-D array of temperatures
 - `F_total` : Total energy absorbed by the facet
-- `k`       : Thermal conductivity [W/m/K]
-- `l`       : Thermal skin depth [m]
+- `Γ`       : Thermal inertia [tiu]
+- `P`       : Period of thermal cycle [sec]
 - `Δz̄`      : Non-dimensional step in depth, normalized by thermal skin depth `l`
 - `ε`       : Emissivity
 """

--- a/src/thermophysics.jl
+++ b/src/thermophysics.jl
@@ -45,6 +45,10 @@ abstract type AbstractThermoParams end
     struct NonUniformThermoParams
 
 # Fields
+- `P`     : Cycle of thermal cycle (rotation period) [sec]
+- `l`     : Thermal skin depth [m]
+- `Γ`     : Thermal inertia [J ⋅ m⁻² ⋅ K⁻¹ ⋅ s⁻⁰⁵ (tiu)]
+- `λ`     : Non-dimensional coefficient for heat diffusion equation
 - `A_B`   : Bond albedo
 - `A_TH`  : Albedo at thermal radiation wavelength
 - `ε`     : Emissivity
@@ -57,36 +61,34 @@ abstract type AbstractThermoParams end
 - `z_max` : Depth of the bottom of a heat conduction equation [m]
 - `Δz`    : Depth step width [m]
 - `Nz`    : Number of depth steps
-
-- `P`     : Cycle of thermal cycle (rotation period) [sec]
-- `l`     : Thermal skin depth [m]
-- `Γ`     : Thermal inertia [J ⋅ m⁻² ⋅ K⁻¹ ⋅ s⁻⁰⁵ (tiu)]
-- `λ`     : Non-dimensional coefficient for heat diffusion equation
 """
 struct NonUniformThermoParams <: AbstractThermoParams
-    A_B ::Vector{Float64}
-    A_TH::Vector{Float64}
-    ε   ::Vector{Float64}
+    P       ::Float64          # Common for all faces
+    l       ::Vector{Float64}
+    Γ       ::Vector{Float64}
+    λ       ::Vector{Float64}
+    A_B     ::Vector{Float64}
+    A_TH    ::Vector{Float64}
+    ε       ::Vector{Float64}
 
-    t_begin::Float64    # Common for all faces
-    t_end  ::Float64    # Common for all faces
-    Δt     ::Float64    # Common for all faces
-    Nt     ::Int        # Common for all faces
+    t_begin ::Float64          # Common for all faces
+    t_end   ::Float64          # Common for all faces
+    Δt      ::Float64          # Common for all faces
+    Nt      ::Int              # Common for all faces
 
-    z_max::Float64      # Common for all faces
-    Δz   ::Float64      # Common for all faces
-    Nz   ::Int          # Common for all faces
-
-    P::Float64          # Common for all faces
-    l::Vector{Float64}
-    Γ::Vector{Float64}
-    λ::Vector{Float64}
+    z_max   ::Float64          # Common for all faces
+    Δz      ::Float64          # Common for all faces
+    Nz      ::Int              # Common for all faces
 end
 
 """
     struct UniformThermoParams
 
 # Fields
+- `P`     : Thermal cycle (rotation period) [sec]
+- `l`     : Thermal skin depth [m]
+- `Γ`     : Thermal inertia [J ⋅ m⁻² ⋅ K⁻¹ ⋅ s⁻⁰⁵ (tiu)]
+- `λ`     : Non-dimensional coefficient for heat diffusion equation
 - `A_B`   : Bond albedo
 - `A_TH`  : Albedo at thermal radiation wavelength
 - `ε`     : Emissivity
@@ -99,37 +101,31 @@ end
 - `z_max` : Depth of the bottom of a heat conduction equation [m]
 - `Δz`    : Depth step width [m]
 - `Nz`    : Number of depth steps
-
-- `P`     : Thermal cycle (rotation period) [sec]
-- `l`     : Thermal skin depth [m]
-- `Γ`     : Thermal inertia [J ⋅ m⁻² ⋅ K⁻¹ ⋅ s⁻⁰⁵ (tiu)]
-- `λ`     : Non-dimensional coefficient for heat diffusion equation
 """
 struct UniformThermoParams <: AbstractThermoParams
-    A_B ::Float64
-    A_TH::Float64
-    ε   ::Float64
+    P       ::Float64
+    l       ::Float64
+    Γ       ::Float64
+    λ       ::Float64
+    A_B     ::Float64
+    A_TH    ::Float64
+    ε       ::Float64
 
-    t_begin::Float64
-    t_end  ::Float64
-    Δt     ::Float64
-    Nt     ::Int
+    t_begin ::Float64
+    t_end   ::Float64
+    Δt      ::Float64
+    Nt      ::Int
 
-    z_max::Float64
-    Δz   ::Float64
-    Nz   ::Int
-
-    P::Float64
-    l::Float64
-    Γ::Float64
-    λ::Float64
+    z_max   ::Float64
+    Δz      ::Float64
+    Nz      ::Int
 end
 
 
 """
     thermoparams(; A_B, A_TH, k, ρ, Cp, ε, t_begin, t_end, Nt, z_max, Nz, P)
 """
-function thermoparams(; A_B, A_TH, ε, t_begin, t_end, Nt, z_max, Nz, P, l, Γ)
+function thermoparams(; P, l, Γ, A_B, A_TH, ε, t_begin, t_end, Nt, z_max, Nz)
 
     Δt = (t_end - t_begin) / (Nt - 1)
     Δz = z_max / (Nz - 1)
@@ -147,9 +143,9 @@ function thermoparams(; A_B, A_TH, ε, t_begin, t_end, Nt, z_max, Nz, P, l, Γ)
         Γ     isa Real && (Γ    = fill(Γ,    LENGTH))
         λ     isa Real && (λ    = fill(λ,    LENGTH))
         
-        NonUniformThermoParams(A_B, A_TH, ε, t_begin, t_end, Δt, Nt, z_max, Δz, Nz, P, l, Γ, λ)
+        NonUniformThermoParams(P, l, Γ, λ, A_B, A_TH, ε, t_begin, t_end, Δt, Nt, z_max, Δz, Nz)
     else
-        UniformThermoParams(A_B, A_TH, ε, t_begin, t_end, Δt, Nt, z_max, Δz, Nz, P, l, Γ, λ)
+        UniformThermoParams(P, l, Γ, λ, A_B, A_TH, ε, t_begin, t_end, Δt, Nt, z_max, Δz, Nz)
     end
 end
 

--- a/src/thermophysics.jl
+++ b/src/thermophysics.jl
@@ -150,7 +150,7 @@ function thermoparams(; P, l, Γ, A_B, A_TH, ε, t_begin, t_end, Nt, z_max, Nz)
 end
 
 
-function Base.show(io::IO, params::AbstractThermoParams)
+function Base.show(io::IO, params::UniformThermoParams)
 
     msg =  "⋅-----------------------------------⋅\n"
     msg *= "|     Thermophysical parameters     |\n"

--- a/test/TPM_Didymos.jl
+++ b/test/TPM_Didymos.jl
@@ -78,21 +78,28 @@
         shape2 = AsteroidThermoPhysicalModels.load_shape_obj(path_shape2_obj; scale=1000, find_visible_facets=true)
         AsteroidThermoPhysicalModels.save_shape_jld(path_shape2_jld, shape2)
     end
+    
+    ##= Thermal properties =##
+    P  = SPICE.convrt(AsteroidThermoPhysicalModels.DIDYMOS[:P], "hours", "seconds")
+    k  = 0.125
+    ρ  = 2170.
+    Cₚ = 600.
 
-    ##= TPM =##
+    l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)
+    Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)
+
     thermo_params = AsteroidThermoPhysicalModels.thermoparams(  # [Michel+2016; Naidu+2020]
         A_B     = 0.059,  # Bolometric Bond albedo
         A_TH    = 0.0,
-        k       = 0.125,
-        ρ       = 2170.,
-        Cp      = 600.,
         ε       = 0.9,
         t_begin = et_range[begin],
         t_end   = et_range[end],
         Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
-        P       = SPICE.convrt(AsteroidThermoPhysicalModels.DIDYMOS[:P], "hours", "seconds"),
+        P       = P,
+        l       = l,
+        Γ       = Γ,
     )
 
     AsteroidThermoPhysicalModels.init_temperature!(shape1, thermo_params, 200.)

--- a/test/TPM_Didymos.jl
+++ b/test/TPM_Didymos.jl
@@ -89,6 +89,9 @@
     Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)
 
     thermo_params = AsteroidThermoPhysicalModels.thermoparams(  # [Michel+2016; Naidu+2020]
+        P       = P,
+        l       = l,
+        Γ       = Γ,
         A_B     = 0.059,  # Bolometric Bond albedo
         A_TH    = 0.0,
         ε       = 0.9,
@@ -97,9 +100,6 @@
         Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
-        P       = P,
-        l       = l,
-        Γ       = Γ,
     )
 
     AsteroidThermoPhysicalModels.init_temperature!(shape1, thermo_params, 200.)

--- a/test/TPM_Didymos.jl
+++ b/test/TPM_Didymos.jl
@@ -2,7 +2,7 @@
 @testset "TPM_Didymos" begin
     msg = """
 
-    ⋅--------------------------- -----⋅
+    ⋅---------------------------------⋅
     |        Test: TPM_Didymos        |
     ⋅---------------------------------⋅
     """
@@ -102,10 +102,12 @@
         Nz      = 41,
     )
 
+    println(thermo_params)
+
+    ##= Run TPM and save the result =##
     AsteroidThermoPhysicalModels.init_temperature!(shape1, thermo_params, 200.)
     AsteroidThermoPhysicalModels.init_temperature!(shape2, thermo_params, 200.)
 
-    # Run TPM and save the result
     savepath = joinpath("TPM_Didymos.jld2")
     shapes = (shape1, shape2)
     suns = (sun_d1, sun_d2)

--- a/test/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu.jl
@@ -90,6 +90,8 @@
         Nz      = 41,
     )
 
+    println(thermo_params)
+
     # Run TPM and save the result
     AsteroidThermoPhysicalModels.init_temperature!(shape, thermo_params, 200.)
     savepath = joinpath("TPM_Ryugu.jld2")

--- a/test/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu.jl
@@ -67,20 +67,27 @@
         AsteroidThermoPhysicalModels.save_shape_jld(path_jld, shape)
     end
 
-    ##= TPM =##
+    ##= Thermal properties =##
+    P = SPICE.convrt(7.63262, "hours", "seconds")
+    k = 0.1
+    ρ = 1270.0
+    Cₚ = 600.0
+    
+    l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)
+    Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)
+
     thermo_params = AsteroidThermoPhysicalModels.thermoparams(
         A_B     = 0.04,  # Bolometric Bond albedo
         A_TH    = 0.0,
-        k       = 0.1,
-        ρ       = 1270.0,
-        Cp      = 600.0,
         ε       = 1.0,
         t_begin = et_range[begin],
         t_end   = et_range[end],
         Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
-        P       = 7.63262 * 3600,
+        P       = P,
+        l       = l,
+        Γ       = Γ,
     )
 
     # Run TPM and save the result

--- a/test/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu.jl
@@ -77,6 +77,9 @@
     Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)
 
     thermo_params = AsteroidThermoPhysicalModels.thermoparams(
+        P       = P,
+        l       = l,
+        Γ       = Γ,
         A_B     = 0.04,  # Bolometric Bond albedo
         A_TH    = 0.0,
         ε       = 1.0,
@@ -85,9 +88,6 @@
         Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
-        P       = P,
-        l       = l,
-        Γ       = Γ,
     )
 
     # Run TPM and save the result

--- a/test/non-uniform_thermoparams.jl
+++ b/test/non-uniform_thermoparams.jl
@@ -92,6 +92,9 @@
     Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)
 
     thermo_params = AsteroidThermoPhysicalModels.thermoparams(
+        P       = P,
+        l       = l,
+        Γ       = Γ,
         A_B     = [r[3] > 0 ? 0.04 : 0.1 for r in shape.face_centers],
         A_TH    = 0.0,
         ε       = [r[3] > 0 ? 1.0 : 0.9  for r in shape.face_centers],
@@ -100,9 +103,6 @@
         Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
-        P       = P,
-        l       = l,
-        Γ       = Γ,
     )
 
     ##= Run TPM and save the result =##

--- a/test/non-uniform_thermoparams.jl
+++ b/test/non-uniform_thermoparams.jl
@@ -69,29 +69,40 @@
         AsteroidThermoPhysicalModels.save_shape_jld(path_jld, shape)
     end
 
-    ##= TPM =##
-    # When thermophysical properties vary from facet to facet
-    # "Northern" hemisphere:
-    #     Bond albedo          : A_B = 0.04 [-]
-    #     Thermal conductivity : k   = 0.1  [W/m/K]
-    #     Emissivity           : ε   = 1.0  [-]
-    # "Southern" hemisphere:
-    #     Bond albedo          : A_B = 0.1  [-]
-    #     Thermal conductivity : k   = 0.3  [W/m/K]
-    #     Emissivity           : ε   = 0.9  [-]
+    ##= Thermal properties =##
+    """
+    When thermophysical properties vary from face to face
+
+    - "Northern" hemisphere:
+        - Bond albedo          : A_B = 0.04 [-]
+        - Thermal conductivity : k   = 0.1  [W/m/K]
+        - Emissivity           : ε   = 1.0  [-]
+    - "Southern" hemisphere:
+        - Bond albedo          : A_B = 0.1  [-]
+        - Thermal conductivity : k   = 0.3  [W/m/K]
+        - Emissivity           : ε   = 0.9  [-]
+    """
+
+    P  = SPICE.convrt(7.63262, "hours", "seconds")
+    k  = [r[3] > 0 ? 0.1 : 0.3  for r in shape.face_centers]
+    ρ  = 1270.0
+    Cₚ = 600.0
+    
+    l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)
+    Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)
+
     thermo_params = AsteroidThermoPhysicalModels.thermoparams(
         A_B     = [r[3] > 0 ? 0.04 : 0.1 for r in shape.face_centers],
         A_TH    = 0.0,
-        k       = [r[3] > 0 ? 0.1 : 0.3  for r in shape.face_centers],
-        ρ       = 1270.0,
-        Cp      = 600.0,
         ε       = [r[3] > 0 ? 1.0 : 0.9  for r in shape.face_centers],
         t_begin = et_range[begin],
         t_end   = et_range[end],
         Nt      = length(et_range),
         z_max   = 0.6,
         Nz      = 41,
-        P       = 7.63262 * 3600,
+        P       = P,
+        l       = l,
+        Γ       = Γ,
     )
 
     ##= Run TPM and save the result =##


### PR DESCRIPTION
 When the heat conduction equation is solved, use `P`, `l`, and `Γ` instead of `k`, `ρ`, and `Cₚ`.