### PR TITLE
Add JuliaFormatter

### DIFF
--- a/.JuliaFormetter.toml
+++ b/.JuliaFormetter.toml
@@ -1,0 +1,1 @@
+style = "sciml"

--- a/.JuliaFormetter.toml
+++ b/.JuliaFormetter.toml
@@ -1,1 +1,1 @@
-style = "sciml"
+style = "blue"

--- a/.github/workflows/Format.yml
+++ b/.github/workflows/Format.yml
@@ -1,0 +1,8 @@
+name: Format suggestions
+on:
+  pull_request:
+jobs:
+  code-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: julia-actions/julia-format@v2

--- a/src/obj.jl
+++ b/src/obj.jl
@@ -11,7 +11,7 @@ end
 """
 function loadobj(shapepath::String; scale=1, static=true, message=true)
 
-    nodes = SVector{3, Float64}[]
+    nodes = SVector{3,   Float64}[]
     faces = SVector{3, Int64}[]
 
     open(shapepath, "r") do f

--- a/src/obj.jl
+++ b/src/obj.jl
@@ -11,8 +11,8 @@ end
 """
 function loadobj(shapepath::String; scale=1, static=true, message=true)
 
-    nodes = SVector{3,   Float64}[]
-    faces = SVector{3, Int64}[]
+    nodes = SVector{3,Float64}[]
+    faces = SVector{3,Int64}[]
 
     open(shapepath, "r") do f
         for line in eachline(f)


### PR DESCRIPTION
This PR adds a formatter without formatting. I would like to add some GitHub Actions for this, but I'm not sure what's the best practice because the [`format_check.yml`](https://github.com/julia-actions/julia-format/blob/master/workflows/format_check.yml) from [the JuliaFormatter documentation](https://domluna.github.io/JuliaFormatter.jl/v1.0.36/#Quick-Start) uses Julia v1.3.0.

I will undraft this PR when I add some `.yml` file for GitHub Actions.