### PR TITLE
Dimensional depth and time in heat conduction equation

### DIFF
--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -214,6 +214,8 @@ function SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING,
 
     broadcast_thermo_params!(thermo_params, shape)
 
+    broadcast_thermo_params!(thermo_params, shape)
+
     n_depth = thermo_params.n_depth
     n_face = length(shape.faces)
 

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -647,7 +647,6 @@ function run_TPM!(stpm::SingleAsteroidThermoPhysicalModel, ephem, times_to_save:
         if show_progress
             showvalues = [
                 ("Timestep ", i_time),
-                ("E_cons   ", result.E_cons[i_time]),
             ]
             ProgressMeter.next!(p; showvalues)
         end
@@ -712,8 +711,6 @@ function run_TPM!(btpm::BinaryAsteroidThermoPhysicalModel, ephem, times_to_save:
         if show_progress
             showvalues = [
                 ("Timestep             ", i_time),
-                ("E_cons for primary   ", result.pri.E_cons[i_time]),
-                ("E_cons for secondary ", result.sec.E_cons[i_time]),
             ]
             ProgressMeter.next!(p; showvalues)
         end

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -646,7 +646,8 @@ function run_TPM!(stpm::SingleAsteroidThermoPhysicalModel, ephem, times_to_save:
         ## Update the progress meter
         if show_progress
             showvalues = [
-                ("Timestep ", i_time),
+                ("Timestep     ", i_time),
+                ("E_out / E_in ", result.E_out[i_time] / result.E_in[i_time]),  # Energy output/input ratio at the time step
             ]
             ProgressMeter.next!(p; showvalues)
         end
@@ -710,7 +711,9 @@ function run_TPM!(btpm::BinaryAsteroidThermoPhysicalModel, ephem, times_to_save:
         ## Update the progress meter
         if show_progress
             showvalues = [
-                ("Timestep             ", i_time),
+                ("Timestep                   ", i_time),
+                ("E_out / E_in for primary   ", result.pri.E_out[i_time] / result.pri.E_in[i_time]),  # Energy output/input ratio on the primary at the time step
+                ("E_out / E_in for secondary ", result.sec.E_out[i_time] / result.sec.E_in[i_time]),  # Energy output/input ratio on the secondary at the time step
             ]
             ProgressMeter.next!(p; showvalues)
         end

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -85,7 +85,8 @@ function forward_euler!(stpm::SingleAsteroidTPM, Δt)
             Cₚ = stpm.thermo_params.heat_capacity[i_face]
             Δz = stpm.thermo_params.Δz
 
-            λ = k * Δt / (ρ * Cₚ * Δz^2)
+            α = thermal_diffusivity(k, ρ, Cₚ)  # Thermal diffusivity [m²/s]
+            λ = α * Δt / Δz^2
             λ ≥ 0.5 && error("The forward Euler method is unstable because λ = $λ. This should be less than 0.5.")
 
             for i_depth in 2:(n_depth-1)

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -64,8 +64,8 @@ function forward_euler!(stpm::SingleAsteroidTPM, Δt)
     n_depth = size(T, 1)
     n_face = size(T, 2)
 
-    ## Zero-conductivity (thermal inertia) case
-    if iszero(stpm.thermo_params.inertia)
+    ## Zero-conductivity case
+    if iszero(stpm.thermo_params.thermal_conductivity)
         for i_face in 1:n_face
             R_vis = stpm.thermo_params.reflectance_vis[i_face]
             R_ir  = stpm.thermo_params.reflectance_ir[i_face]
@@ -80,11 +80,12 @@ function forward_euler!(stpm::SingleAsteroidTPM, Δt)
     ## Non-zero-conductivity (thermal inertia) case
     else
         for i_face in 1:n_face
-            P  = stpm.thermo_params.period
+            k  = stpm.thermo_params.thermal_conductivity[i_face]
+            ρ  = stpm.thermo_params.density[i_face]
+            Cₚ = stpm.thermo_params.heat_capacity[i_face]
             Δz = stpm.thermo_params.Δz
-            l  = stpm.thermo_params.skindepth[i_face]
 
-            λ = (Δt/P) / (Δz/l)^2 / 4π
+            λ = k * Δt / (ρ * Cₚ * Δz^2)
             λ ≥ 0.5 && error("The forward Euler method is unstable because λ = $λ. This should be less than 0.5.")
 
             for i_depth in 2:(n_depth-1)
@@ -242,9 +243,9 @@ function update_upper_temperature!(stpm::SingleAsteroidTPM, i::Integer)
 
     #### Radiation boundary condition ####
     if stpm.BC_UPPER isa RadiationBoundaryCondition
-        P     = stpm.thermo_params.period
-        l     = stpm.thermo_params.skindepth[i]
-        Γ     = stpm.thermo_params.inertia[i]
+        k     = stpm.thermo_params.thermal_conductivity[i]
+        ρ     = stpm.thermo_params.density[i]
+        Cₚ    = stpm.thermo_params.heat_capacity[i]
         R_vis = stpm.thermo_params.reflectance_vis[i]
         R_ir  = stpm.thermo_params.reflectance_ir[i]
         ε     = stpm.thermo_params.emissivity[i]
@@ -252,7 +253,7 @@ function update_upper_temperature!(stpm::SingleAsteroidTPM, i::Integer)
     
         F_sun, F_scat, F_rad = stpm.flux[i, :]
         F_total = flux_total(R_vis, R_ir, F_sun, F_scat, F_rad)
-        update_surface_temperature!(stpm.SOLVER.T, F_total, P, l, Γ, ε, Δz)
+        update_surface_temperature!(stpm.SOLVER.T, F_total, k, ρ, Cₚ, ε, Δz)
     #### Insulation boundary condition ####
     elseif stpm.BC_UPPER isa InsulationBoundaryCondition
         stpm.SOLVER.T[begin] = stpm.SOLVER.T[begin+1]
@@ -266,27 +267,27 @@ end
 
 
 """
-    update_surface_temperature!(T::AbstractVector, F_total::Real, k::Real, l::Real, Δz::Real, ε::Real)
+    update_surface_temperature!(T::AbstractVector, F_total::Real, k::Real, ρ::Real, Cₚ::Real, ε::Real, Δz::Real)
 
 Newton's method to update the surface temperature under radiation boundary condition.
 
 # Arguments
 - `T`       : 1-D array of temperatures
 - `F_total` : Total energy absorbed by the facet
-- `Γ`       : Thermal inertia [tiu]
-- `P`       : Period of thermal cycle [sec]
-- `Δz̄`      : Non-dimensional step in depth, normalized by thermal skin depth `l`
+- `k`       : Thermal conductivity [W/m/K]
+- `ρ`       : Density [kg/m³]
+- `Cₚ`      : Heat capacity [J/kg/K]
 - `ε`       : Emissivity [-]
+- `Δz`      : Depth step width [m]
 """
-function update_surface_temperature!(T::AbstractVector, F_total::Float64, P::Float64, l::Float64, Γ::Float64, ε::Float64, Δz::Float64)
-    Δz̄ = Δz / l    # Dimensionless length of depth step
+function update_surface_temperature!(T::AbstractVector, F_total::Float64, k::Float64, ρ::Float64, Cₚ::Float64, ε::Float64, Δz::Float64)
     εσ = ε * σ_SB
 
     for _ in 1:20
         T_pri = T[begin]
 
-        f = F_total + Γ / √(4π * P) * (T[begin+1] - T[begin]) / Δz̄ - εσ*T[begin]^4
-        df = - Γ / √(4π * P) / Δz̄ - 4*εσ*T[begin]^3             
+        f = F_total + k * (T[begin+1] - T[begin]) / Δz - εσ*T[begin]^4
+        df = - k / Δz - 4*εσ*T[begin]^3             
         T[begin] -= f / df
 
         err = abs(1 - T_pri / T[begin])

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -33,6 +33,20 @@ thermal_skin_depth(P, k, ρ, Cₚ) = @. √(4π * P * k / (ρ * Cₚ))
 thermal_inertia(k, ρ, Cₚ) = @. √(k * ρ * Cₚ)
 
 
+"""
+    thermal_diffusivity(k, ρ, Cp) -> α
+
+# Arguments
+- `k`  : Thermal conductivity [W/m/K]
+- `ρ`  : Material density [kg/m³]
+- `Cₚ` : Heat capacity [J/kg/K]
+
+# Return
+- `α` : Thermal diffusivity [m²/s]
+"""
+thermal_diffusivity(k, ρ, Cₚ) = @. k / (ρ * Cₚ)
+
+
 # ****************************************************************
 #               Struct for thermophysical parameters
 # ****************************************************************

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -43,9 +43,10 @@ abstract type AbstractThermoParams end
     struct ThermoParams
 
 # Fields
-- `period`          : Period of thermal cycle (rotation period) [sec]
-- `skindepth`       : Vector of thermal skin depth for each facet [m]
-- `inertia`         : Vector of thermal inertia for each facet [thermal inertia unit (tiu)]
+- `thermal_conductivity` : Vector of thermal conductivity for each facet [W/m/K]
+- `density`              : Vector of density for each facet [kg/m³]
+- `heat_capacity`        : Vector of heat capacity for each facet [J/kg/K]
+
 - `reflectance_vis` : Vector of reflectance in visible light for each facet [-]
 - `reflectance_ir`  : Vector of reflectance in thermal infrared for each facet [-]
 - `emissivity`      : Vector of emissivity for each facet [-]
@@ -55,9 +56,10 @@ abstract type AbstractThermoParams end
 - `n_depth` : Number of depth steps
 """
 struct ThermoParams <: AbstractThermoParams
-    period          ::Float64
-    skindepth       ::Vector{Float64}
-    inertia         ::Vector{Float64}
+    thermal_conductivity ::Vector{Float64}
+    density              ::Vector{Float64}
+    heat_capacity        ::Vector{Float64}
+
     reflectance_vis ::Vector{Float64}
     reflectance_ir  ::Vector{Float64}
     emissivity      ::Vector{Float64}
@@ -70,42 +72,44 @@ end
 
 """
     ThermoParams(
-        period          ::Float64,
-        skindepth       ::Float64,
-        inertia         ::Float64,
-        reflectance_vis ::Float64,
-        reflectance_ir  ::Float64,
-        emissivity      ::Float64,
-        z_max           ::Float64,
-        Δz              ::Float64,
-        n_depth         ::Int
+        thermal_conductivity ::Float64,
+        density              ::Float64,
+        heat_capacity        ::Float64,
+        reflectance_vis      ::Float64,
+        reflectance_ir       ::Float64,
+        emissivity           ::Float64,
+        z_max                ::Float64,
+        Δz                   ::Float64,
+        n_depth              ::Int
     )
 
 Outer constructor for `ThermoParams`.
 You can give the same parameters to all facets by `Float64`.
 
 # Arguments
-- `period`          : Period of thermal cycle (rotation period) [sec]
-- `skindepth`       : Thermal skin depth [m]
-- `inertia`         : Thermal inertia [tiu]
+- `thermal_conductivity` : Thermal conductivity [W/m/K]
+- `density`              : Density [kg/m³]
+- `heat_capacity`        : Heat capacity [J/kg/K]
+
 - `reflectance_vis` : Reflectance in visible light [-]
 - `reflectance_ir`  : Reflectance in thermal infrared [-]
 - `emissivity`      : Emissivity [-]
+
 - `z_max`           : Depth of the lower boundary of a heat conduction equation [m]
 - `Δz`              : Depth step width [m]
 - `n_depth`         : Number of depth steps
 """
 function ThermoParams(
-    period          ::Float64,
-    skindepth       ::Float64,
-    inertia         ::Float64,
-    reflectance_vis ::Float64,
-    reflectance_ir  ::Float64,
-    emissivity      ::Float64,
-    z_max           ::Float64,
-    Δz              ::Float64,
-    n_depth         ::Int
+    thermal_conductivity ::Float64,
+    density              ::Float64,
+    heat_capacity        ::Float64,
+    reflectance_vis      ::Float64,
+    reflectance_ir       ::Float64,
+    emissivity           ::Float64,
+    z_max                ::Float64,
+    Δz                   ::Float64,
+    n_depth              ::Int
 )
 
-    return ThermoParams(period, [skindepth], [inertia], [reflectance_vis], [reflectance_ir], [emissivity], z_max, Δz, n_depth)
+    return ThermoParams(thermal_conductivity, [density], [heat_capacity], [reflectance_vis], [reflectance_ir], [emissivity], z_max, Δz, n_depth)
 end

--- a/src/thermo_params.jl
+++ b/src/thermo_params.jl
@@ -111,5 +111,5 @@ function ThermoParams(
     n_depth              ::Int
 )
 
-    return ThermoParams(thermal_conductivity, [density], [heat_capacity], [reflectance_vis], [reflectance_ir], [emissivity], z_max, Δz, n_depth)
+    return ThermoParams([thermal_conductivity], [density], [heat_capacity], [reflectance_vis], [reflectance_ir], [emissivity], z_max, Δz, n_depth)
 end

--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -54,7 +54,7 @@
     P₂ = SPICE.convrt(11.93 , "hours", "seconds")  # Rotation period of Dimorphos
 
     n_cycle = 2  # Number of cycles to perform TPM
-    n_step_in_cycle = 72  # Number of time steps in one rotation period
+    n_step_in_cycle = 120  # Number of time steps in one rotation period
 
     et_begin = SPICE.utc2et("2027-02-18T00:00:00")  # Start time of TPM
     et_end   = et_begin + P₂ * n_cycle  # End time of TPM
@@ -94,10 +94,6 @@
     ρ  = 2170.0  # Density [kg/m³]
     Cₚ = 600.0   # Heat capacity [J/kg/K]
 
-    l₁ = AsteroidThermoPhysicalModels.thermal_skin_depth(P₁, k, ρ, Cₚ)  # Thermal skin depth for Didymos
-    l₂ = AsteroidThermoPhysicalModels.thermal_skin_depth(P₂, k, ρ, Cₚ)  # Thermal skin depth for Dimorphos
-    Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)          # Thermal inertia for Didymos and Dimorphos [tiu]
-
     R_vis = 0.059  # Reflectance in visible light [-]
     R_ir  = 0.0    # Reflectance in thermal infrared [-]
     ε     = 0.9    # Emissivity [-]
@@ -106,8 +102,8 @@
     n_depth = 41  # Number of depth steps
     Δz = z_max / (n_depth - 1)  # Depth step width [m]
 
-    thermo_params1 = AsteroidThermoPhysicalModels.ThermoParams(P₁, l₁, Γ, R_vis, R_ir, ε, z_max, Δz, n_depth)
-    thermo_params2 = AsteroidThermoPhysicalModels.ThermoParams(P₂, l₂, Γ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params1 = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params2 = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ##= Setting of TPM =##
     stpm1 = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape1, thermo_params1;

--- a/test/TPM_Ryugu/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu/TPM_Ryugu.jl
@@ -46,7 +46,7 @@
     P = SPICE.convrt(7.63262, "hours", "seconds")  # Rotation period of Ryugu
 
     n_cycle = 2  # Number of cycles to perform TPM
-    n_step_in_cycle = 72  # Number of time steps in one rotation period
+    n_step_in_cycle = 120  # Number of time steps in one rotation period
 
     et_begin = SPICE.utc2et("2018-07-01T00:00:00")  # Start time of TPM
     et_end   = et_begin + P * n_cycle  # End time of TPM
@@ -74,7 +74,7 @@
     k  = 0.1     # Thermal conductivity [W/m/K]
     ρ  = 1270.0  # Density [kg/m³]
     Cₚ = 600.0   # Heat capacity [J/kg/K]
-    
+
     l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)  # Thermal skin depth [m]
     Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)        # Thermal inertia [tiu]
 
@@ -83,10 +83,10 @@
     ε     = 1.0   # Emissivity [-]
 
     z_max = 0.6   # Depth of the lower boundary of a heat conduction equation [m]
-    n_depth = 41  # Number of depth steps
+    n_depth = 61  # Number of depth steps
     Δz = z_max / (n_depth - 1)  # Depth step width [m]
 
-    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(P, l, Γ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ##= Setting of TPM =##
     stpm = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params;

--- a/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
+++ b/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
@@ -87,21 +87,18 @@
     """
 
     k  = [r[3] > 0 ? 0.1 : 0.3  for r in shape.face_centers]  # Thermal conductivity [W/m/K]
-    ρ  = 1270.0  # Density [kg/m³]
-    Cₚ = 600.0   # Heat capacity [J/kg/K]
-    
-    l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)  # Thermal skin depth [m]
-    Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)        # Thermal inertia [tiu]
+    ρ  = fill(1270.0, n_face)  # Density [kg/m³]
+    Cₚ = fill(600.0, n_face)   # Heat capacity [J/kg/K]
 
     R_vis = [r[3] > 0 ? 0.04 : 0.1 for r in shape.face_centers]  # Reflectance in visible light [-]
-    R_ir  = [r[3] > 0 ? 1.0 : 0.9  for r in shape.face_centers]  # Reflectance in thermal infrared [-]
+    R_ir  = [r[3] > 0 ? 0.0 : 0.0  for r in shape.face_centers]  # Reflectance in thermal infrared [-]
     ε     = fill(1.0, n_face)   # Emissivity [-]
 
     z_max = 0.6   # Depth of the lower boundary of a heat conduction equation [m]
     n_depth = 41  # Number of depth steps
     Δz = z_max / (n_depth - 1)  # Depth step width [m]
 
-    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(P, l, Γ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ##= Setting of TPM =##
     stpm = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params;

--- a/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
+++ b/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
@@ -35,8 +35,9 @@
     n_face = length(shape.faces)  # Number of faces
 
     ##= Thermal properties: zero-conductivity case =##
-    l = 0.0  # Thermal skin depth [m]
-    Γ = 0.0  # Thermal inertia [J m⁻² K⁻¹ s⁻¹/2]
+    k  = 0.0     # Thermal conductivity [W/m/K]
+    ρ  = 1270.0  # Density [kg/m³]
+    Cₚ = 600.0   # Heat capacity [J/kg/K]
 
     R_vis = 0.1  # Reflectance in visible light [-]
     R_ir  = 0.0  # Reflectance in thermal infrared [-]
@@ -46,7 +47,7 @@
     n_depth = 41  # Number of depth steps
     Δz = z_max / (n_depth - 1)  # Depth step width [m]
 
-    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(P, l, Γ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ##= Setting of TPM =##
     stpm = AsteroidThermoPhysicalModels.SingleAsteroidThermoPhysicalModel(shape, thermo_params;

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -20,13 +20,9 @@
     )
 
     ##= Thermal properties =##
-    P  = 1.0
-    k  = 1.0
-    ρ  = 1.0
-    Cₚ = 1.0
-    
-    l = AsteroidThermoPhysicalModels.thermal_skin_depth(P, k, ρ, Cₚ)
-    Γ = AsteroidThermoPhysicalModels.thermal_inertia(k, ρ, Cₚ)
+    k  = 0.1     # Thermal conductivity [W/m/K]
+    ρ  = 1270.0  # Density [kg/m³]
+    Cₚ = 600.0   # Heat capacity [J/kg/K]
 
     R_vis = 0.0  # Reflectance in visible light [-]
     R_ir  = 0.0  # Reflectance in thermal infrared [-]
@@ -36,7 +32,7 @@
     n_depth = 101  # Number of depth steps
     Δz = z_max / (n_depth - 1)  # Depth step width [m]
 
-    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(P, l, Γ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ##= TPMs with different solvers =##
     SELF_SHADOWING = false

--- a/test/thermal_radiation.jl
+++ b/test/thermal_radiation.jl
@@ -68,7 +68,7 @@
     n_depth = 41  # Number of depth steps
     Δz = z_max / (n_depth - 1)  # Depth step width [m]
 
-    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(P, l, Γ, R_vis, R_ir, ε, z_max, Δz, n_depth)
+    thermo_params = AsteroidThermoPhysicalModels.ThermoParams(k, ρ, Cₚ, R_vis, R_ir, ε, z_max, Δz, n_depth)
 
     ##= Setting of TPM =##
     stpm = AsteroidThermoPhysicalModels.SingleAsteroidTPM(shape, thermo_params;


### PR DESCRIPTION
`ThermoParams` contains thermal conductivity, density, and heat capacity to solve a heat conduction equation, instead of rotation period, thermal inertia, and thermal skin depth. With this PR, time `t` and depth `z` are treated as quantities with dimensions ([s] and [m], respectively).