### PR TITLE
Refactor `flux` representation in `SingleAsteroidThermoPhysicalModel`

### DIFF
--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -156,10 +156,9 @@ broadcast_thermo_params!(thermo_params::ThermoParams, shape::ShapeModel) = broad
 - `shape`          : Shape model
 - `thermo_params`  : Thermophysical parameters
 
-- `flux`           : Flux on each face. Matrix of size (Number of faces, 3). Three components are:
-    - `flux[:, 1]`     : F_sun,  flux of direct sunlight
-    - `flux[:, 2]`     : F_scat, flux of scattered light
-    - `flux[:, 3]`     : F_rad,  flux of thermal emission from surrounding surface
+- `flux_sun`       : Flux of direct sunlight on each face [W/m²]
+- `flux_scat`      : Flux of scattered light on each face [W/m²]
+- `flux_rad`       : Flux of thermal emission from surrounding surface on each face [W/m²]
 - `temperature`    : Temperature matrix `(n_depth, n_face)` according to the number of depth cells `n_depth` and the number of faces `n_face`.
 
 - `face_forces`    : Thermal force on each face
@@ -179,7 +178,9 @@ struct SingleAsteroidThermoPhysicalModel{P<:AbstractThermoParams, S<:HeatConduct
     shape          ::ShapeModel
     thermo_params  ::P
 
-    flux           ::Matrix{Float64}  # (n_face, 3)
+    flux_sun       ::Vector{Float64}  # Flux of direct sunlight
+    flux_scat      ::Vector{Float64}  # Flux of scattered light
+    flux_rad       ::Vector{Float64}  # Flux of thermal emission from surrounding surface
     temperature    ::Matrix{Float64}  # (n_depth, n_face)
 
     face_forces    ::Vector{SVector{3, Float64}}
@@ -217,14 +218,16 @@ function SingleAsteroidThermoPhysicalModel(shape, thermo_params; SELF_SHADOWING,
     n_depth = thermo_params.n_depth
     n_face = length(shape.faces)
 
-    flux = zeros(n_face, 3)
+    flux_sun = zeros(n_face)
+    flux_scat = zeros(n_face)
+    flux_rad = zeros(n_face)
     temperature = zeros(n_depth, n_face)
 
     face_forces = zeros(SVector{3, Float64}, n_face)
     force  = zero(MVector{3, Float64})
     torque = zero(MVector{3, Float64})
 
-    SingleAsteroidThermoPhysicalModel(shape, thermo_params, flux, temperature, face_forces, force, torque, SELF_SHADOWING, SELF_HEATING, SOLVER, BC_UPPER, BC_LOWER)
+    SingleAsteroidThermoPhysicalModel(shape, thermo_params, flux_sun, flux_scat, flux_rad, temperature, face_forces, force, torque, SELF_SHADOWING, SELF_HEATING, SOLVER, BC_UPPER, BC_LOWER)
 end
 
 

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -72,7 +72,9 @@ function forward_euler!(stpm::SingleAsteroidTPM, Δt)
             ε     = stpm.thermo_params.emissivity[i_face]
             εσ = ε * σ_SB
 
-            F_sun, F_scat, F_rad = stpm.flux[i_face, :]
+            F_sun = stpm.flux_sun[i_face]
+            F_scat = stpm.flux_scat[i_face]
+            F_rad = stpm.flux_rad[i_face]
             F_total = flux_total(R_vis, R_ir, F_sun, F_scat, F_rad)
 
             stpm.temperature[begin, i_face] = (F_total / εσ)^(1/4)
@@ -250,8 +252,10 @@ function update_upper_temperature!(stpm::SingleAsteroidTPM, i::Integer)
         ε     = stpm.thermo_params.emissivity[i]
         Δz    = stpm.thermo_params.Δz
     
-        F_sun, F_scat, F_rad = stpm.flux[i, :]
-        F_total = flux_total(R_vis, R_ir, F_sun, F_scat, F_rad)
+            F_sun = stpm.flux_sun[i]
+            F_scat = stpm.flux_scat[i]
+            F_rad = stpm.flux_rad[i]
+            F_total = flux_total(R_vis, R_ir, F_sun, F_scat, F_rad)
         update_surface_temperature!(stpm.SOLVER.T, F_total, P, l, Γ, ε, Δz)
     #### Insulation boundary condition ####
     elseif stpm.BC_UPPER isa InsulationBoundaryCondition

--- a/src/non_grav.jl
+++ b/src/non_grav.jl
@@ -22,9 +22,9 @@ function update_thermal_force!(stpm::SingleAsteroidTPM)
         n̂ᵢ = stpm.shape.face_normals[i]
         aᵢ = stpm.shape.face_areas[i]
 
-        F_sun  = stpm.flux[i, 1]
-        F_scat = stpm.flux[i, 2]
-        F_rad  = stpm.flux[i, 3]
+        F_sun  = stpm.flux_sun[i]
+        F_scat = stpm.flux_scat[i]
+        F_rad  = stpm.flux_rad[i]
         Tᵢ = stpm.temperature[begin, i]
 
         ## Total emittance from face i , Eᵢ [W/m²].


### PR DESCRIPTION
## Changes

This PR refactors the flux representation in the `SingleAsteroidThermoPhysicalModel` structure by replacing the `flux` matrix with three explicit vectors:

- `flux_sun::Vector{Float64}`: Direct solar flux on each face
- `flux_scat::Vector{Float64}`: Scattered light flux on each face
- `flux_rad::Vector{Float64}`: Thermal radiation flux from surrounding surfaces on each face

## Motivation

The previous implementation used a matrix `flux` with columns representing different types of fluxes. This approach required using numerical indices (e.g., `flux[i, 1]` for solar flux), which reduced code readability and made it harder to understand what each flux component represented.

## Benefits

- __Improved code readability__: Each flux type now has a descriptive name, making the code more self-documenting
- __Type safety__: Explicit vector types for each flux component provide better type information
- __Maintainability__: Easier to understand and modify code that deals with specific flux types
- __Extensibility__: Easier to add new flux types in the future if needed

## Implementation

Modified files:

- `src/TPM.jl`: Updated the structure definition
- `src/energy_flux.jl`: Updated flux calculation functions
- `src/heat_conduction.jl`: Updated temperature calculation functions
- `src/non_grav.jl`: Updated thermal force calculation functions

All functionality remains unchanged, this is purely a refactoring to improve code clarity.
