### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -45,7 +45,7 @@ After running the simulation, you will get the following output files. You shoul
 - `physical_quantities.csv`
     - `time`     : Time steps
     - `E_in`     : Input energy per second on the whole surface [W]
-    - `E_out`    : Output enegey per second from the whole surface [W]
+    - `E_out`    : Output energy per second from the whole surface [W]
     - `E_cons`   : Energy conservation ratio [-], ratio of total energy going out to total energy coming in during the last rotation cycle
     - `force_x`  : x-component of the thermal force
     - `force_y`  : y-component of the thermal force

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -282,7 +282,7 @@ Output data format for `SingleAsteroidThermoPhysicalModel`
 ## Saved at all time steps
 - `times`  : Timesteps, given the same vector as `ephem.time` [s]
 - `E_in`   : Input energy per second on the whole surface [W]
-- `E_out`  : Output enegey per second from the whole surface [W]
+- `E_out`  : Output energey per second from the whole surface [W]
 - `force`  : Thermal force on the asteroid [N]
 - `torque` : Thermal torque on the asteroid [N ⋅ m]
 

--- a/src/TPM.jl
+++ b/src/TPM.jl
@@ -282,7 +282,7 @@ Output data format for `SingleAsteroidThermoPhysicalModel`
 ## Saved at all time steps
 - `times`  : Timesteps, given the same vector as `ephem.time` [s]
 - `E_in`   : Input energy per second on the whole surface [W]
-- `E_out`  : Output energey per second from the whole surface [W]
+- `E_out`  : Output energy per second from the whole surface [W]
 - `force`  : Thermal force on the asteroid [N]
 - `torque` : Thermal torque on the asteroid [N ⋅ m]
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -43,7 +43,7 @@ end
 """
     energy_out(stpm::SingleAsteroidTPM) -> E_out
 
-Output enegey per second from the whole surface [W]
+Output energy per second from the whole surface [W]
 
 # Arguments
 - `stpm` : Thermophysical model for a single asteroid


### PR DESCRIPTION
## Summary
- fix typo in docs output description
- fix typo in `SingleAsteroidThermoPhysicalModelResult`
- fix typo in `energy_out` docstring

## Testing
- `julia --project=. -e 'using Pkg; Pkg.test()'` *(fails: command not found)*