### PR TITLE
Fix coordinate transformation bug in update_flux_all\!

### DIFF
--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -205,7 +205,7 @@ function update_flux_all!(btpm::BinaryAsteroidTPM, r☉₁::StaticVector{3}, r�
     # Pre-compute all coordinate transformations
     r☉₂ = R₁₂ * (r☉₁ - r₁₂)  # Sun's position in the secondary's frame
     R₂₁ = R₁₂'               # Rotation matrix from secondary to primary
-    r₂₁ = -R₂₁ * r₁₂         # Primary's position in the secondary's frame
+    r₂₁ = -R₁₂ * r₁₂         # Primary's position in the secondary's frame
     
     # Update all fluxes
     update_flux_sun!(btpm, r☉₁, r☉₂, r₁₂, r₂₁, R₁₂, R₂₁)


### PR DESCRIPTION
## Summary

This PR fixes a coordinate transformation bug in the `update_flux_all\!` function that was causing incorrect eclipse shadowing calculations in binary asteroid systems.

## Bug Description

The calculation of `r₂₁` (primary's position in secondary's frame) was incorrect:

```julia
# Incorrect (current main branch)
r₂₁ = -R₂₁ * r₁₂ = -R₁₂' * r₁₂

# Correct (this PR)
r₂₁ = -R₁₂ * r₁₂
```

## Mathematical Derivation

Given the coordinate transformation from primary to secondary frame:
```
p₂ = R₁₂ * p₁ + t₁₂
```

For the secondary's center:
- In primary frame: `r₁₂`
- In secondary frame: `(0,0,0)`

This gives us: `0 = R₁₂ * r₁₂ + t₁₂`

Therefore: `t₁₂ = -R₁₂ * r₁₂`

For the primary's center:
- In primary frame: `(0,0,0)`
- In secondary frame: `r₂₁`

Applying the transformation:
```
r₂₁ = R₁₂ * 0 + t₁₂ = t₁₂ = -R₁₂ * r₁₂
```

## Impact

This bug was causing incorrect mutual shadowing calculations in binary asteroid systems, as reported in the TIRI simulation notebook after PR #182.

## Test Plan

- [ ] Verify TIRI simulations produce correct eclipse shadowing
- [ ] Run existing binary asteroid tests
- [ ] Add unit test for coordinate transformation correctness

🤖 Generated with [Claude Code](https://claude.ai/code)