### PR TITLE
Fix benchmark compatibility with latest API changes

### DIFF
--- a/benchmark/BENCHMARK_LOG.md
+++ b/benchmark/BENCHMARK_LOG.md
@@ -192,6 +192,61 @@ Component analysis (Ryugu):
 
 ---
 
+### 2025-07-13 - v0.0.8-DEV - 7dc6cbb
+
+**Environment:**
+- Julia: 1.11.6
+- CPU: Apple M4
+- OS: macOS Darwin 24.5.0
+- Threads: 1
+
+**Results:**
+```
+Ryugu (49,152 faces):
+  1 rotation (72 steps):
+    Time: 5.086 seconds
+    Memory: 5.80 KiB
+    Allocations: 16
+  20 rotations (1,440 steps):
+    Time: 103.099 seconds
+    Memory: 152.17 KiB
+    Allocations: 20
+
+Didymos-Dimorphos (1,996 + 3,072 faces = 5,068 total):
+  1 rotation (72 steps):
+    Time: 4.663 seconds (median of 2 samples)
+    Memory: 28.11 MiB
+    Allocations: 747,283
+  20 rotations (1,440 steps):
+    Time: 89.279 seconds
+    Memory: 530.65 MiB
+    Allocations: 13,376,385
+
+Component analysis (Ryugu):
+  - Shadow calculation: 1.040 seconds (72 calls) = 0.014 s/call
+  - Self-heating: 1.833 seconds (72 calls) = 0.025 s/call
+  - Flux calculation (unified API): 2.890 seconds (72 calls) = 0.040 s/call
+  - Temperature update: 1.633 seconds (72 steps) = 0.023 s/step
+
+Component analysis (Didymos):
+  - Flux calculation (unified API): 4.468 seconds (median, 72 calls) = 0.062 s/call
+    Memory: 28.09 MiB, Allocations: 747,251
+
+Memory benchmark:
+  - Ryugu full simulation: 5.120 seconds, 1.88 MiB, 36 allocations
+```
+
+**Notes:**
+- First benchmark after updating to AsteroidShapeModels.jl v0.4.1 with unified flux API
+- Unified API (`update_flux_all!`) shows excellent performance for both single and binary asteroids
+- Binary system allocations remain high due to `apply_eclipse_shadowing!` implementation
+- Shadow calculation performance improved significantly: 0.379 s/call → 0.014 s/call for Ryugu
+- Overall performance improvement for Ryugu: component benchmarks ~20x faster than v0.0.8-DEV-a89cfe4
+- Binary system shows improved time performance despite high allocations
+- The unified API successfully encapsulates complex coordinate transformations without performance penalty
+
+---
+
 ## Template for new entries
 
 ```markdown

--- a/benchmark/Manifest.toml
+++ b/benchmark/Manifest.toml
@@ -1,6 +1,6 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.5"
+julia_version = "1.11.6"
 manifest_format = "2.0"
 project_hash = "58e359614ee5ee40f8133c0b641e37ee6f6f2a01"
 
@@ -47,9 +47,9 @@ version = "1.11.0"
 
 [[deps.AsteroidShapeModels]]
 deps = ["FileIO", "GeometryBasics", "ImplicitBVH", "LinearAlgebra", "MeshIO", "StaticArrays"]
-git-tree-sha1 = "d96a8263d8e6a3a5555cd0dc4a940a001d74ae59"
+git-tree-sha1 = "33d07e1e3171642b41147a42ccedb08c488d188b"
 uuid = "a7943d8e-5d65-4248-ae23-0082f5115a05"
-version = "0.4.0"
+version = "0.4.1"
 
 [[deps.AsteroidThermoPhysicalModels]]
 deps = ["AsteroidShapeModels", "CSV", "DataFrames", "LinearAlgebra", "ProgressMeter", "StaticArrays", "Statistics"]
@@ -117,9 +117,9 @@ version = "0.12.1"
 
 [[deps.Compat]]
 deps = ["TOML", "UUIDs"]
-git-tree-sha1 = "8ae8d32e09f0dcf42a36b90d4e17f5dd2e4c4215"
+git-tree-sha1 = "3a3dfb30697e96a440e4149c8c51bf32f818c0f3"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "4.16.0"
+version = "4.17.0"
 weakdeps = ["Dates", "LinearAlgebra"]
 
     [deps.Compat.extensions]
@@ -235,22 +235,17 @@ git-tree-sha1 = "83cf05ab16a73219e5f6bd1bdfa9848fa24ac627"
 uuid = "46192b85-c4d5-4398-a991-12ede77f4527"
 version = "0.2.0"
 
-[[deps.GeoFormatTypes]]
-git-tree-sha1 = "8e233d5167e63d708d41f87597433f59a0f213fe"
-uuid = "68eda718-8dee-11e9-39e7-89f7f65f511f"
-version = "0.4.4"
-
-[[deps.GeoInterface]]
-deps = ["DataAPI", "Extents", "GeoFormatTypes"]
-git-tree-sha1 = "294e99f19869d0b0cb71aef92f19d03649d028d5"
-uuid = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
-version = "1.4.1"
-
 [[deps.GeometryBasics]]
-deps = ["EarCut_jll", "Extents", "GeoInterface", "IterTools", "LinearAlgebra", "PrecompileTools", "Random", "StaticArrays"]
-git-tree-sha1 = "2670cf32dcf0229c9893b895a9afe725edb23545"
+deps = ["EarCut_jll", "Extents", "IterTools", "LinearAlgebra", "PrecompileTools", "Random", "StaticArrays"]
+git-tree-sha1 = "1f5a80f4ed9f5a4aada88fc2db456e637676414b"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.5.9"
+version = "0.5.10"
+
+    [deps.GeometryBasics.extensions]
+    GeometryBasicsGeoInterfaceExt = "GeoInterface"
+
+    [deps.GeometryBasics.weakdeps]
+    GeoInterface = "cf35fbd7-0cd7-5166-be24-54bfbe79505f"
 
 [[deps.ImplicitBVH]]
 deps = ["AcceleratedKernels", "ArgCheck", "Atomix", "DocStringExtensions", "GPUArraysCore", "KernelAbstractions", "LinearAlgebra"]
@@ -305,9 +300,9 @@ version = "0.21.4"
 
 [[deps.KernelAbstractions]]
 deps = ["Adapt", "Atomix", "InteractiveUtils", "MacroTools", "PrecompileTools", "Requires", "StaticArrays", "UUIDs"]
-git-tree-sha1 = "4efa9cec6f308e0f492ea635421638bff81cf6f8"
+git-tree-sha1 = "38a03910123867c11af988e8718d12c98bf6a234"
 uuid = "63c18a36-062a-441e-b654-da1e3ab1ce7c"
-version = "0.9.36"
+version = "0.9.37"
 
     [deps.KernelAbstractions.extensions]
     EnzymeExt = "EnzymeCore"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -46,7 +46,8 @@ The benchmark suite includes:
 - Mutual shadowing and heating enabled
 
 ### 3. **Component Analysis**
-- Shadow calculation overhead
+- Unified flux calculation (update_flux_all!)
+- Shadow calculation overhead (individual)
 - Self-heating calculations
 - Temperature update performance
 - Memory allocation patterns
@@ -85,7 +86,7 @@ To track performance over time:
 ## Optimization Targets
 
 Key areas for optimization based on profiling:
-1. **Shadow calculations** (isilluminated function) - O(N²) complexity
-2. **Visibility graph queries** - Frequent allocations
-3. **Heat conduction solvers** - Lack of SIMD optimizations
-4. **Memory allocations** - Unnecessary array copies
+1. **Shadow calculations** - Now using batch processing with AsteroidShapeModels.jl v0.4.1
+2. **Coordinate transformations** - Centralized in update_flux_all!
+3. **Heat conduction solvers** - Potential for SIMD optimizations
+4. **Memory allocations** - Reduced with unified API

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -68,13 +68,11 @@ println("\nResults saved to: $results_file")
 print_summary(results)
 
 # Get package version
-try
-    pkg_version = Pkg.project().version
-    if isnothing(pkg_version)
-        pkg_version = "dev"
-    end
+pkg_version = try
+    ver = Pkg.project().version
+    isnothing(ver) ? "dev" : ver
 catch
-    pkg_version = "unknown"
+    "unknown"
 end
 
 # Export human-readable report

--- a/benchmark/run_benchmarks.jl
+++ b/benchmark/run_benchmarks.jl
@@ -68,7 +68,14 @@ println("\nResults saved to: $results_file")
 print_summary(results)
 
 # Get package version
-pkg_version = Pkg.project().version
+try
+    pkg_version = Pkg.project().version
+    if isnothing(pkg_version)
+        pkg_version = "dev"
+    end
+catch
+    pkg_version = "unknown"
+end
 
 # Export human-readable report
 report_file = joinpath(@__DIR__, "results", "benchmark_report_$(timestamp).txt")


### PR DESCRIPTION
## Summary
- Update benchmarks to work with AsteroidShapeModels.jl v0.4.1 and unified flux API
- Fix package version handling in benchmark runner
- Record benchmark results showing significant performance improvements

## Changes
1. **Benchmark code updates**:
   - Import `update_flux_all\!` function for unified flux calculations
   - Update binary asteroid flux calculation to use new API
   - Fix package version retrieval scope issue

2. **Manifest.toml handling**:
   - Use `Pkg.develop(PackageSpec(path=".."))` to properly link local package
   - Ensures benchmarks use the current development version

3. **Benchmark results**:
   - Shadow calculation: 0.379 s/call → 0.014 s/call (26x faster)
   - Overall component benchmarks ~20x faster for Ryugu
   - Unified API shows excellent performance without overhead

## Test plan
- [x] Run benchmarks locally with `julia --project=benchmark benchmark/run_benchmarks.jl`
- [x] Verify all benchmarks complete successfully
- [x] Record results in BENCHMARK_LOG.md
- [x] Compare performance with previous runs

## Related
- Depends on PR #182 (unified flux API)
- Depends on PR #183 (coordinate transformation fix)
- Related to issue #179 (AsteroidShapeModels.jl v0.4.0 integration)

🤖 Generated with [Claude Code](https://claude.ai/code)