### PR TITLE
feat: compute global-level solar flux for `HierarchicalSingleAsteroidThermoPhysicalState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,8 +89,9 @@ grid_params.Δz
   `SingleAsteroidThermoPhysicalState` per roughness-carrying face)
 - **`SingleAsteroidThermoPhysicalProblem` accepts a `HierarchicalShapeModel`**: the problem
   type is unchanged (`shape` is already parametric); the solver builds the hierarchical state
-  by dispatching on the shape type. `init_temperature!` and `surface_temperature` support the
-  new state. Sub-face flux and temperature updates land in later releases of the v0.3.0 series
+  by dispatching on the shape type. `init_temperature!`, `surface_temperature`, and
+  `update_flux_sun!` (global level) support the new state. Sub-face flux and temperature
+  updates land in later releases of the v0.3.0 series
 
 ### Changed
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -179,6 +179,43 @@ end
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 
+# Shared implementation of the solar flux update for the faces of `shape`.
+# `state` may be a `SingleAsteroidThermoPhysicalState` or a
+# `HierarchicalSingleAsteroidThermoPhysicalState`; both carry `illuminated_faces`,
+# `flux_sun`, and `problem.with_self_shadowing` with the same layout. The shape is
+# passed explicitly because a `HierarchicalShapeModel` keeps its faces under
+# `global_shape` rather than as direct fields.
+function _update_flux_sun!(state, shape::ShapeModel, r☉::StaticVector{3})
+    # Calculate solar flux and direction
+    r̂☉ = normalize(r☉)
+    F☉ = SOLAR_CONST / (norm(r☉) * m2au)^2
+
+    # Update illumination states
+    if state.problem.with_self_shadowing
+        # Check face_visibility_graph availability for self-shadowing
+        if isnothing(shape.face_visibility_graph)
+            error(
+                "face_visibility_graph must be built when `with_self_shadowing` is enabled. " *
+                "Use `build_face_visibility_graph!(shape)` or load shape with `with_face_visibility=true`."
+            )
+        end
+        update_illumination!(state.illuminated_faces, shape, r̂☉; with_self_shadowing=true)
+    else
+        update_illumination!(state.illuminated_faces, shape, r̂☉; with_self_shadowing=false)
+    end
+
+    # Calculate flux for each face
+    for i in eachindex(shape.faces)
+        if state.illuminated_faces[i]
+            n̂ = shape.face_normals[i]
+            state.flux_sun[i] = F☉ * (n̂ ⋅ r̂☉)
+        else
+            state.flux_sun[i] = 0.0
+        end
+    end
+end
+
+
 """
     update_flux_sun!(state::SingleAsteroidThermoPhysicalState, r☉::StaticVector{3})
 
@@ -194,42 +231,36 @@ For each face, the solar flux is calculated as:
 2. Normalize sun direction: r̂☉ = r☉ / |r☉|
 3. Face flux: F_sun = F☉ × max(0, n̂ · r̂☉)
 
-where n̂ is the face normal. If `SELF_SHADOWING` is enabled, the function also
+where n̂ is the face normal. If `with_self_shadowing` is enabled, the function also
 checks whether each face is shadowed by other parts of the asteroid.
 
 # Notes
 - The input vector `r☉` must not be normalized (used for distance calculation)
 - Faces with negative dot product (facing away from Sun) receive zero flux
-- Shadowed faces (when `SELF_SHADOWING = true`) also receive zero flux
+- Shadowed faces (when `with_self_shadowing = true`) also receive zero flux
 """
 function update_flux_sun!(state::SingleAsteroidThermoPhysicalState, r☉::StaticVector{3})
-    # Calculate solar flux and direction
-    r̂☉ = normalize(r☉)
-    F☉ = SOLAR_CONST / (norm(r☉) * m2au)^2
-    
-    # Update illumination states
-    if state.problem.with_self_shadowing
-        # Check face_visibility_graph availability for self-shadowing
-        if isnothing(state.problem.shape.face_visibility_graph)
-            error(
-                "face_visibility_graph must be built when SELF_SHADOWING is enabled. " *
-                "Use `build_face_visibility_graph!(shape)` or load shape with `with_face_visibility=true`."
-            )
-        end
-        update_illumination!(state.illuminated_faces, state.problem.shape, r̂☉; with_self_shadowing=true)
-    else
-        update_illumination!(state.illuminated_faces, state.problem.shape, r̂☉; with_self_shadowing=false)
-    end
+    _update_flux_sun!(state, state.problem.shape, r☉)
+end
 
-    # Calculate flux for each face
-    for i in eachindex(state.problem.shape.faces)
-        if state.illuminated_faces[i]
-            n̂ = state.problem.shape.face_normals[i]
-            state.flux_sun[i] = F☉ * (n̂ ⋅ r̂☉)
-        else
-            state.flux_sun[i] = 0.0
-        end
-    end
+
+"""
+    update_flux_sun!(state::HierarchicalSingleAsteroidThermoPhysicalState, r☉::StaticVector{3})
+
+Update the direct solar irradiation flux on every global face of an asteroid with surface roughness.
+
+# Arguments
+- `state::HierarchicalSingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid with surface roughness
+- `r☉::StaticVector{3}`     : Position vector from asteroid to Sun in body-fixed frame (NOT normalized) [m]
+
+# Notes
+- Only the global level (`state.problem.shape.global_shape`) is updated; the algorithm and
+  self-shadowing treatment are the same as for `SingleAsteroidThermoPhysicalState`.
+- The sub-face states in `state.roughness_states` are left untouched. Their illumination and
+  solar flux in the local frame of each roughness model are computed separately.
+"""
+function update_flux_sun!(state::HierarchicalSingleAsteroidThermoPhysicalState, r☉::StaticVector{3})
+    _update_flux_sun!(state, state.problem.shape.global_shape, r☉)
 end
 
 """

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -179,13 +179,12 @@ end
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 
-# Shared implementation of the solar flux update for the faces of `shape`.
-# `state` may be a `SingleAsteroidThermoPhysicalState` or a
-# `HierarchicalSingleAsteroidThermoPhysicalState`; both carry `illuminated_faces`,
-# `flux_sun`, and `problem.with_self_shadowing` with the same layout. The shape is
-# passed explicitly because a `HierarchicalShapeModel` keeps its faces under
-# `global_shape` rather than as direct fields.
-function _update_flux_sun!(state, shape::ShapeModel, r☉::StaticVector{3})
+# Shared implementation of the solar flux update for the faces of `shape`. The shape is
+# passed explicitly because a `HierarchicalShapeModel` keeps its faces under `global_shape`
+# rather than as direct fields, so the caller decides which level is being updated.
+function _update_flux_sun!(
+    state::SingleLevelThermoPhysicalState, shape::ShapeModel, r☉::StaticVector{3},
+)
     # Calculate solar flux and direction
     r̂☉ = normalize(r☉)
     F☉ = SOLAR_CONST / (norm(r☉) * m2au)^2

--- a/src/tpm_state.jl
+++ b/src/tpm_state.jl
@@ -132,6 +132,23 @@ end
 
 
 """
+    const SingleLevelThermoPhysicalState
+
+States that describe one set of faces directly: `illuminated_faces`, `flux_sun`, `flux_scat`,
+`flux_rad`, `temperature` and `face_forces` share the same layout in both, so a per-face
+implementation written against one applies to the other. `BinaryAsteroidThermoPhysicalState` holds two such
+states rather than face data of its own, and is deliberately excluded.
+
+For `HierarchicalSingleAsteroidThermoPhysicalState` these fields describe the global faces;
+its sub-face states are themselves `SingleAsteroidThermoPhysicalState`s.
+"""
+const SingleLevelThermoPhysicalState = Union{
+    SingleAsteroidThermoPhysicalState,
+    HierarchicalSingleAsteroidThermoPhysicalState,
+}
+
+
+"""
     surface_temperature(state::SingleAsteroidThermoPhysicalState) -> T_surface
 
 Extract the surface temperature (uppermost layer) for all faces.

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -150,10 +150,10 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
         # The global level of a hierarchical state must reproduce the plain ShapeModel result
         # exactly: the sub-face machinery must not perturb the global solar flux.
         path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
-        au = 1 / AsteroidThermoPhysicalModels.m2au
+        au2m = AsteroidThermoPhysicalModels.au2m
         r☉s = [
-            SVector(1.0, 0.0, 0.0) * au,
-            SVector(0.3, -0.5, 0.8) * 1.2au,
+            SVector(1.0, 0.0, 0.0) * au2m,        # 1.0 au
+            SVector(0.3, -0.5, 0.8) * 1.2au2m,    # 1.2 au, oblique
         ]
 
         for with_self_shadowing in (false, true)
@@ -215,7 +215,7 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
         state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
 
         shape_hier.global_shape.face_visibility_graph = nothing
-        r☉ = SVector(1.0, 0.0, 0.0) / AsteroidThermoPhysicalModels.m2au
+        r☉ = SVector(1.0, 0.0, 0.0) * AsteroidThermoPhysicalModels.au2m
         @test_throws ErrorException AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
     end
 end

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -202,5 +202,15 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
                 end
             end
         end
+
+        # Self-shadowing on a global shape whose visibility graph was dropped after
+        # construction must fail loudly rather than silently skip the shadow test.
+        shape_hier = load_shape_obj(path_obj; as_hierarchical=true)
+        add_roughness_models!(shape_hier, roughness_model)
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=true, with_self_heating=false)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+        shape_hier.global_shape.face_visibility_graph = nothing
+        @test_throws ErrorException AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉s[1])
     end
 end

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -5,6 +5,7 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
 - _build_single_state dispatch for HierarchicalShapeModel
 - init_temperature! for HierarchicalSingleAsteroidThermoPhysicalState (Real and AbstractMatrix)
 - automatic preparation of the geometric data required for self-shadowing and self-heating
+- update_flux_sun! on the global level, compared against the plain ShapeModel result
 =#
 
 @testset "HierarchicalSingleAsteroidThermoPhysicalState" begin
@@ -143,5 +144,63 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
 
         @test !isnothing(hier_shape4.global_shape.face_visibility_graph)
         @test isnothing(hier_shape4.global_shape.face_max_elevations)  # not needed by self-heating
+    end
+
+    @testset "update_flux_sun! (global level)" begin
+        # The global level of a hierarchical state must reproduce the plain ShapeModel result
+        # exactly: the sub-face machinery must not perturb the global solar flux.
+        path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
+        au = 1 / AsteroidThermoPhysicalModels.m2au
+        r☉s = [
+            SVector(1.0, 0.0, 0.0) * au,
+            SVector(0.3, -0.5, 0.8) * 1.2au,
+        ]
+
+        for with_self_shadowing in (false, true)
+            shape_plain = load_shape_obj(path_obj)
+            shape_hier  = load_shape_obj(path_obj; as_hierarchical=true)
+            add_roughness_models!(shape_hier, roughness_model)
+
+            problem_plain = SingleAsteroidThermoPhysicalProblem(shape_plain, thermo_params, grid_params;
+                with_self_shadowing, with_self_heating=false)
+            problem_hier  = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+                with_self_shadowing, with_self_heating=false)
+
+            state_plain = AsteroidThermoPhysicalModels._build_single_state(problem_plain, CrankNicolson())
+            state_hier  = AsteroidThermoPhysicalModels._build_single_state(problem_hier,  CrankNicolson())
+
+            for r☉ in r☉s
+                AsteroidThermoPhysicalModels.update_flux_sun!(state_plain, r☉)
+                AsteroidThermoPhysicalModels.update_flux_sun!(state_hier,  r☉)
+
+                # Global level matches the plain ShapeModel result exactly
+                @test state_hier.illuminated_faces == state_plain.illuminated_faces
+                @test state_hier.flux_sun          == state_plain.flux_sun
+
+                # Physical sanity: the icosahedron is convex, so illumination reduces to n̂ ⋅ r̂☉ > 0.
+                # Faces whose normal is perpendicular to the Sun direction (cosθ ≈ 0 up to
+                # round-off) are skipped, since their illumination flag is not well defined.
+                r̂☉ = normalize(r☉)
+                F☉ = AsteroidThermoPhysicalModels.SOLAR_CONST / (norm(r☉) * AsteroidThermoPhysicalModels.m2au)^2
+                for (i, n̂) in enumerate(shape_hier.global_shape.face_normals)
+                    cosθ = n̂ ⋅ r̂☉
+                    abs(cosθ) < 1e-8 && continue
+                    if cosθ > 0
+                        @test state_hier.illuminated_faces[i]
+                        @test state_hier.flux_sun[i] ≈ F☉ * cosθ
+                    else
+                        @test !state_hier.illuminated_faces[i]
+                        @test state_hier.flux_sun[i] == 0.0
+                    end
+                end
+                @test any(state_hier.illuminated_faces) && !all(state_hier.illuminated_faces)
+
+                # Sub-face states are not touched by the global-level update
+                for rs in state_hier.roughness_states
+                    @test !any(rs.illuminated_faces)
+                    @test all(rs.flux_sun .== 0.0)
+                end
+            end
+        end
     end
 end

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -202,15 +202,20 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
                 end
             end
         end
+    end
 
-        # Self-shadowing on a global shape whose visibility graph was dropped after
-        # construction must fail loudly rather than silently skip the shadow test.
-        shape_hier = load_shape_obj(path_obj; as_hierarchical=true)
+    @testset "update_flux_sun! requires face_visibility_graph for self-shadowing" begin
+        # The problem constructor builds the graph, but the global shape is mutable and may
+        # lose it afterwards. Self-shadowing must then fail loudly rather than silently skip
+        # the shadow test.
+        shape_hier = load_shape_obj(joinpath(@__DIR__, "shape", "icosahedron.obj"); as_hierarchical=true)
         add_roughness_models!(shape_hier, roughness_model)
         problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
             with_self_shadowing=true, with_self_heating=false)
         state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+
         shape_hier.global_shape.face_visibility_graph = nothing
-        @test_throws ErrorException AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉s[1])
+        r☉ = SVector(1.0, 0.0, 0.0) / AsteroidThermoPhysicalModels.m2au
+        @test_throws ErrorException AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
     end
 end


### PR DESCRIPTION
## Summary

Phase 2 of surface roughness support (v0.3.0): make `update_flux_sun!` work on the global level of a `HierarchicalSingleAsteroidThermoPhysicalState`. Follows #222.

- **`_update_flux_sun!(state, shape::ShapeModel, r☉)`** (`src/energy_flux.jl`): the existing body of `update_flux_sun!`, with the shape passed explicitly instead of read from `state.problem.shape`. A `HierarchicalShapeModel` keeps its faces, normals, and visibility graph under `global_shape`, so the caller decides which `ShapeModel` the flux is computed on. The helper takes either state type; both carry `illuminated_faces`, `flux_sun`, and `problem.with_self_shadowing` with the same layout.
- **`update_flux_sun!(state::SingleAsteroidThermoPhysicalState, r☉)`**: now delegates to the helper with `state.problem.shape`. Behavior unchanged.
- **`update_flux_sun!(state::HierarchicalSingleAsteroidThermoPhysicalState, r☉)`**: new dispatch that passes `state.problem.shape.global_shape`. Only the global level is updated; `roughness_states` are left untouched until the local-frame sub-face illumination lands in a later PR.
- The `face_visibility_graph` error message now names the current flag `with_self_shadowing` rather than the pre-v0.2.0 `SELF_SHADOWING`; the docstring is updated the same way.

Scope is deliberately the solar flux only. Scattered/thermal flux, temperature update, sub-face computations, and the hierarchical `update_flux_all!` follow in separate PRs, in the order laid out in the design note.

## Test plan

- [x] New testset `update_flux_sun! (global level)` in `test/test_hierarchical_state.jl`: builds the same icosahedron as a plain `ShapeModel` and as a `HierarchicalShapeModel` with a crater on every face, then for `with_self_shadowing = false` and `true` and two Sun directions asserts that
  - global-level `illuminated_faces` and `flux_sun` are **identical** (`==`) to the plain result — pins that the sub-face machinery does not perturb the global level,
  - illumination and flux follow `n̂ ⋅ r̂☉` on the convex shape (faces with `|cosθ| < 1e-8` skipped, their flag is round-off dependent),
  - every roughness sub-state still has all-`false` illumination and zero flux.
- [x] Full `Pkg.test()` passes locally (Julia 1.12.6); the Ryugu / Didymos / zero-conductivity end-to-end tests cover the unchanged `SingleAsteroidThermoPhysicalState` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)