### PR TITLE
refactor: report shape geometry preparation on a single line

### DIFF
--- a/src/tpm_problem.jl
+++ b/src/tpm_problem.jl
@@ -88,14 +88,19 @@ end
 """
     _log_elapsed(f, what::AbstractString)
 
-Run `f`, reporting both its start and its elapsed time. Building the geometric data for a
-large shape model takes minutes, so the closing message tells the user that the run has moved
-on rather than stalled.
+Run `f`, reporting what it is about to do and, once it returns, how long it took — both on a
+single line. Preparing the geometric data for a large shape model takes minutes, so the
+opening half tells the user what the wait is for and the closing half reports its cost.
+
+The line is written to `stdout` rather than through `@info`, because a log record cannot be
+completed after the fact. This matches how `solve` already reports its progress.
 """
 function _log_elapsed(f, what::AbstractString)
-    @info "$what..."
+    printstyled("[ Info: "; color=:cyan, bold=true)
+    print("$what... ")
+    flush(stdout)
     elapsed = @elapsed f()
-    @info "$what: done in $(round(elapsed; digits=1)) s"
+    println("done ($(round(elapsed; digits=2)) s)")
 end
 
 


### PR DESCRIPTION
## Summary

Follow-up to #222. Preparing the geometric data required by `with_self_shadowing` / `with_self_heating` reported each step with two log lines — one before the work and one after:

```
[ Info: Building face_visibility_graph for self-shadowing...
[ Info: Building face_visibility_graph for self-shadowing: done in 12.9 s
[ Info: Computing face_max_elevations for self-shadowing...
[ Info: Computing face_max_elevations for self-shadowing: done in 0.0 s
```

Two lines to say the same thing is redundant, and a step that finishes instantly reported `0.0 s` twice over.

A log record cannot be completed after the fact, so `@info` cannot produce this as one line. Keep the line open on `stdout` instead and append the outcome when the call returns:

```
[ Info: Building face_visibility_graph for self-shadowing... done (12.88 s)
[ Info: Computing face_max_elevations for self-shadowing... done (0.34 s)
```

The opening half is flushed before the work starts, so a build that takes minutes on a fine shape model is still visibly in progress rather than looking like a hang. The elapsed time now uses two decimals, since one decimal rendered a fast step as `0.0 s`, which reads as "nothing happened".

## Notes

- Writing to `stdout` means log-level filtering and custom loggers no longer apply to these two messages. This matches the package's existing behaviour: `solve` already reports its progress to `stdout` through ProgressMeter rather than through the logging system.
- The `[ Info: ` prefix is reproduced with `printstyled` to stay visually consistent with the surrounding `@info` output. Colour is dropped automatically when `stdout` is not a TTY, so CI logs are unaffected.

## Test plan

- [x] All existing tests pass
- [x] Verified the rendered output on the 49k-face Ryugu shape (`test/shape/SHAPE_SFM_49k_v20180804.obj`), shown above

🤖 Generated with [Claude Code](https://claude.com/claude-code)
