### PR TITLE
feat: compute global-level scattering and thermal radiation for `HierarchicalSingleAsteroidThermoPhysicalState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,9 +89,10 @@ grid_params.Δz
   `SingleAsteroidThermoPhysicalState` per roughness-carrying face)
 - **`SingleAsteroidThermoPhysicalProblem` accepts a `HierarchicalShapeModel`**: the problem
   type is unchanged (`shape` is already parametric); the solver builds the hierarchical state
-  by dispatching on the shape type. `init_temperature!`, `surface_temperature`, and
-  `update_flux_sun!` (global level) support the new state. Sub-face flux and temperature
-  updates land in later releases of the v0.3.0 series
+  by dispatching on the shape type. `init_temperature!`, `surface_temperature`, and the
+  global-level flux updates (`update_flux_sun!`, `update_flux_scat_single!`,
+  `update_flux_rad_single!`) support the new state. Sub-face flux and temperature updates
+  land in later releases of the v0.3.0 series
 
 ### Changed
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -256,7 +256,8 @@ Update the direct solar irradiation flux on every global face of an asteroid wit
 - Only the global level (`state.problem.shape.global_shape`) is updated; the algorithm and
   self-shadowing treatment are the same as for `SingleAsteroidThermoPhysicalState`.
 - The sub-face states in `state.roughness_states` are left untouched. Their illumination and
-  solar flux in the local frame of each roughness model are computed separately.
+  solar flux in the local frame of each roughness model will be handled by the sub-face flux
+  update.
 """
 function update_flux_sun!(state::HierarchicalSingleAsteroidThermoPhysicalState, r☉::StaticVector{3})
     _update_flux_sun!(state, state.problem.shape.global_shape, r☉)
@@ -327,6 +328,29 @@ end
 # ║                 Energy flux: Scattering                           ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
+# Shared implementation of the single-scattering update for the faces of `shape`. As for
+# `_update_flux_sun!`, the shape is passed explicitly so the caller decides which level of a
+# `HierarchicalShapeModel` is being updated.
+function _update_flux_scat_single!(state::SingleLevelThermoPhysicalState, shape::ShapeModel)
+    state.problem.with_self_heating == false && return
+    isnothing(shape.face_visibility_graph) && return
+
+    for i_face in eachindex(shape.faces)
+        state.flux_scat[i_face] = 0.
+
+        # Face properties visible from `i_face`: Face indices and view factors
+        visible_indices = get_visible_face_indices(shape.face_visibility_graph, i_face)
+        view_factors = get_view_factors(shape.face_visibility_graph, i_face)
+
+        for (j, fᵢⱼ) in zip(visible_indices, view_factors)
+            R_vis = state.problem.thermo_params.reflectance_vis[j]
+
+            state.flux_scat[i_face] += fᵢⱼ * R_vis * state.flux_sun[j]
+        end
+    end
+end
+
+
 """
     update_flux_scat_single!(state::SingleAsteroidThermoPhysicalState)
 
@@ -336,22 +360,27 @@ Update flux of scattered sunlight, only considering single scattering.
 - `state` : Thermophysical simulation state for a single asteroid
 """
 function update_flux_scat_single!(state::SingleAsteroidThermoPhysicalState)
-    state.problem.with_self_heating == false && return
-    isnothing(state.problem.shape.face_visibility_graph) && return
+    _update_flux_scat_single!(state, state.problem.shape)
+end
 
-    for i_face in eachindex(state.problem.shape.faces)
-        state.flux_scat[i_face] = 0.
-        
-        # Face properties visible from `i_face`: Face indices and view factors
-        visible_indices = get_visible_face_indices(state.problem.shape.face_visibility_graph, i_face)
-        view_factors = get_view_factors(state.problem.shape.face_visibility_graph, i_face)
-        
-        for (j, fᵢⱼ) in zip(visible_indices, view_factors)
-            R_vis = state.problem.thermo_params.reflectance_vis[j]
 
-            state.flux_scat[i_face] += fᵢⱼ * R_vis * state.flux_sun[j]
-        end
-    end
+"""
+    update_flux_scat_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
+
+Update flux of scattered sunlight between the global faces of an asteroid with surface roughness,
+only considering single scattering.
+
+# Arguments
+- `state` : Thermophysical simulation state for a single asteroid with surface roughness
+
+# Notes
+- Only the global level (`state.problem.shape.global_shape`) is updated, from the global-level
+  `flux_sun` computed by `update_flux_sun!`.
+- The sub-face states in `state.roughness_states` are left untouched. Scattering within each
+  roughness model will be handled by the sub-face flux update.
+"""
+function update_flux_scat_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
+    _update_flux_scat_single!(state, state.problem.shape.global_shape)
 end
 
 """
@@ -380,6 +409,29 @@ end
 # ║                Energy flux: Thermal radiation                     ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
+# Shared implementation of the thermal-radiation absorption update for the faces of `shape`.
+function _update_flux_rad_single!(state::SingleLevelThermoPhysicalState, shape::ShapeModel)
+    state.problem.with_self_heating == false && return
+    isnothing(shape.face_visibility_graph) && return
+
+    for i in eachindex(shape.faces)
+        state.flux_rad[i] = 0.
+
+        # Face properties visible from `i_face`: Face indices and view factors
+        visible_indices = get_visible_face_indices(shape.face_visibility_graph, i)
+        view_factors = get_view_factors(shape.face_visibility_graph, i)
+
+        for (j, fᵢⱼ) in zip(visible_indices, view_factors)
+            ε    = state.problem.thermo_params.emissivity[j]
+            R_ir = state.problem.thermo_params.reflectance_ir[j]
+            Tⱼ   = state.temperature[begin, j]
+
+            state.flux_rad[i] += ε * σ_SB * (1 - R_ir) * fᵢⱼ * Tⱼ^4
+        end
+    end
+end
+
+
 """
     update_flux_rad_single!(state::SingleAsteroidThermoPhysicalState)
 
@@ -390,24 +442,27 @@ Single radiation-absorption is only considered, assuming albedo is close to zero
 - `state` : Thermophysical simulation state for a single asteroid
 """
 function update_flux_rad_single!(state::SingleAsteroidThermoPhysicalState)
-    state.problem.with_self_heating == false && return
-    isnothing(state.problem.shape.face_visibility_graph) && return
+    _update_flux_rad_single!(state, state.problem.shape)
+end
 
-    for i in eachindex(state.problem.shape.faces)
-        state.flux_rad[i] = 0.
-        
-        # Face properties visible from `i_face`: Face indices and view factors
-        visible_indices = get_visible_face_indices(state.problem.shape.face_visibility_graph, i)
-        view_factors = get_view_factors(state.problem.shape.face_visibility_graph, i)
-        
-        for (j, fᵢⱼ) in zip(visible_indices, view_factors)
-            ε    = state.problem.thermo_params.emissivity[j]
-            R_ir = state.problem.thermo_params.reflectance_ir[j]
-            Tⱼ   = state.temperature[begin, j]
-            
-            state.flux_rad[i] += ε * σ_SB * (1 - R_ir) * fᵢⱼ * Tⱼ^4
-        end
-    end
+
+"""
+    update_flux_rad_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
+
+Update flux of absorption of thermal radiation between the global faces of an asteroid with
+surface roughness.
+
+# Arguments
+- `state` : Thermophysical simulation state for a single asteroid with surface roughness
+
+# Notes
+- Only the global level (`state.problem.shape.global_shape`) is updated, from the global-level
+  surface temperatures.
+- The sub-face states in `state.roughness_states` are left untouched. Radiative exchange within
+  each roughness model will be handled by the sub-face flux update.
+"""
+function update_flux_rad_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
+    _update_flux_rad_single!(state, state.problem.shape.global_shape)
 end
 
 """

--- a/src/tpm_state.jl
+++ b/src/tpm_state.jl
@@ -136,8 +136,8 @@ end
 
 States that describe one set of faces directly: `illuminated_faces`, `flux_sun`, `flux_scat`,
 `flux_rad`, `temperature` and `face_forces` share the same layout in both, so a per-face
-implementation written against one applies to the other. `BinaryAsteroidThermoPhysicalState` holds two such
-states rather than face data of its own, and is deliberately excluded.
+implementation written against one applies to the other. `BinaryAsteroidThermoPhysicalState`
+holds two such states rather than face data of its own, and is deliberately excluded.
 
 For `HierarchicalSingleAsteroidThermoPhysicalState` these fields describe the global faces;
 its sub-face states are themselves `SingleAsteroidThermoPhysicalState`s.

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -6,6 +6,7 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
 - init_temperature! for HierarchicalSingleAsteroidThermoPhysicalState (Real and AbstractMatrix)
 - automatic preparation of the geometric data required for self-shadowing and self-heating
 - update_flux_sun! on the global level, compared against the plain ShapeModel result
+- update_flux_scat_single! / update_flux_rad_single! on the global level, likewise
 =#
 
 @testset "HierarchicalSingleAsteroidThermoPhysicalState" begin
@@ -217,5 +218,72 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
         shape_hier.global_shape.face_visibility_graph = nothing
         r☉ = SVector(1.0, 0.0, 0.0) * AsteroidThermoPhysicalModels.au2m
         @test_throws ErrorException AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+    end
+
+    @testset "update_flux_scat_single! / update_flux_rad_single! (global level)" begin
+        # Self-heating vanishes identically on a convex shape, so the icosahedron used above
+        # cannot tell a working implementation from a broken one. A crater is concave: its
+        # faces see each other, and both self-heating terms are non-zero.
+        make_crater(; as_hierarchical) =
+            create_shape_crater(0.4, 0.1; Nx=8, Ny=8, as_hierarchical)
+
+        shape_plain = make_crater(as_hierarchical=false)
+        shape_hier  = make_crater(as_hierarchical=true)
+        add_roughness_models!(shape_hier, create_shape_crater(0.4, 0.1; Nx=4, Ny=4))
+
+        problem_plain = SingleAsteroidThermoPhysicalProblem(shape_plain, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+        problem_hier  = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+
+        state_plain = AsteroidThermoPhysicalModels._build_single_state(problem_plain, CrankNicolson())
+        state_hier  = AsteroidThermoPhysicalModels._build_single_state(problem_hier,  CrankNicolson())
+
+        # Vary the temperature from face to face, so that a wrong face index in the radiation
+        # term would change the result rather than cancel out.
+        n_faces = length(shape_plain.faces)
+        T₀ = repeat(reshape(range(200.0, 300.0; length=n_faces) |> collect, 1, n_faces),
+                    grid_params.n_depth)
+        AsteroidThermoPhysicalModels.init_temperature!(state_plain, T₀)
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier,  T₀)
+
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        for state in (state_plain, state_hier)
+            AsteroidThermoPhysicalModels.update_flux_sun!(state, r☉)
+            AsteroidThermoPhysicalModels.update_flux_scat_single!(state)
+            AsteroidThermoPhysicalModels.update_flux_rad_single!(state)
+        end
+
+        # Global level matches the plain ShapeModel result exactly
+        @test state_hier.flux_scat == state_plain.flux_scat
+        @test state_hier.flux_rad  == state_plain.flux_rad
+
+        # The comparison is not vacuous: the concave shape really does exchange energy
+        @test any(>(0), state_hier.flux_scat)
+        @test any(>(0), state_hier.flux_rad)
+
+        # Sub-face states are not touched by the global-level update
+        for rs in state_hier.roughness_states
+            @test all(rs.flux_scat .== 0.0)
+            @test all(rs.flux_rad  .== 0.0)
+        end
+    end
+
+    @testset "self-heating disabled leaves the global fluxes at zero" begin
+        shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8, as_hierarchical=true)
+        add_roughness_models!(shape_hier, create_shape_crater(0.4, 0.1; Nx=4, Ny=4))
+
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier, 300.0)
+
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, SVector(0.0, 0.0, 1.0) * AsteroidThermoPhysicalModels.au2m)
+        AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
+        AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
+
+        @test all(state_hier.flux_scat .== 0.0)
+        @test all(state_hier.flux_rad  .== 0.0)
+        @test any(>(0), state_hier.flux_sun)  # the shape is lit, so the zeros are the flag's doing
     end
 end


### PR DESCRIPTION
## Summary

Follow-up to #223, which did the same for the solar flux. Extract the per-face bodies of `update_flux_scat_single!` and `update_flux_rad_single!` into helpers that take the shape explicitly, and add the `HierarchicalSingleAsteroidThermoPhysicalState` dispatches on top of them.

```julia
_update_flux_scat_single!(state::SingleLevelThermoPhysicalState, shape::ShapeModel)
_update_flux_rad_single!(state::SingleLevelThermoPhysicalState,  shape::ShapeModel)

update_flux_scat_single!(state::HierarchicalSingleAsteroidThermoPhysicalState) =
    _update_flux_scat_single!(state, state.problem.shape.global_shape)
```

With this, all three flux terms are available at the global level of a hierarchical state.

Both terms read `thermo_params` by face index. For a hierarchical state that is the global face index, and `ThermoParams` is expanded to the global face count at construction, so the indexing is consistent.

## Test plan

- [x] Global-level `flux_scat` and `flux_rad` match the plain `ShapeModel` result exactly
- [x] Sub-face states are left untouched
- [x] `with_self_heating = false` leaves both fluxes at zero while `flux_sun` is non-zero, so the zeros are attributable to the flag rather than to an unlit shape
- [x] All existing tests pass

The tests use a **crater** rather than the icosahedron used by the existing hierarchical tests. Self-heating vanishes identically on a convex shape — every view factor is zero — so an icosahedron cannot distinguish a working implementation from one that computes nothing. The crater is concave, and the tests assert `any(>(0), flux_scat)` and `any(>(0), flux_rad)` so the comparison against the plain `ShapeModel` cannot pass vacuously. Temperatures vary from face to face, so a wrong face index in the radiation term changes the result rather than cancelling out.

## Notes

- **`update_flux_all!` is deliberately not wired up for the hierarchical state yet.** It is the entry point that must eventually drive both levels; adding it now would produce a function that looks complete while silently ignoring surface roughness. It lands with the sub-face flux updates.
- The early return when `face_visibility_graph` is missing is kept as is. `_update_flux_sun!` raises an error in the same situation, so the two are inconsistent, but changing it is a behaviour change outside the scope of this PR — and since #222 the problem constructor builds the graph whenever `with_self_heating` is enabled, so the branch is no longer reachable through the normal path.
- Two documentation nits carried over from #223 are fixed here: the note about sub-face states read as if the sub-face computation already existed, and one docstring line was left ragged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
