### PR TITLE
feat: solve global-level heat conduction for `HierarchicalSingleAsteroidThermoPhysicalState`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,10 +89,12 @@ grid_params.Δz
   `SingleAsteroidThermoPhysicalState` per roughness-carrying face)
 - **`SingleAsteroidThermoPhysicalProblem` accepts a `HierarchicalShapeModel`**: the problem
   type is unchanged (`shape` is already parametric); the solver builds the hierarchical state
-  by dispatching on the shape type. `init_temperature!`, `surface_temperature`, and the
+  by dispatching on the shape type. `init_temperature!`, `surface_temperature`, the
   global-level flux updates (`update_flux_sun!`, `update_flux_scat_single!`,
-  `update_flux_rad_single!`) support the new state. Sub-face flux and temperature updates
-  land in later releases of the v0.3.0 series
+  `update_flux_rad_single!`), and the global-level heat conduction (`update_temperature!`
+  with all three solvers) support the new state. The global faces are solved independently
+  of their roughness models and serve as the smooth-surface baseline. Sub-face flux and
+  temperature updates land in later releases of the v0.3.0 series
 
 ### Changed
 

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -16,14 +16,14 @@ in the subsurface of asteroids, including:
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    update_temperature_zero_conductivity!(state::SingleAsteroidThermoPhysicalState)
+    update_temperature_zero_conductivity!(state::SingleLevelThermoPhysicalState)
 
 Update surface temperature for the zero thermal conductivity case.
 When thermal conductivity is zero, there is no heat conduction into the subsurface,
 and the surface temperature is determined solely by instantaneous radiative equilibrium.
 
 # Arguments
-- `state::SingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid
+- `state::SingleLevelThermoPhysicalState` : Thermophysical simulation state for a single asteroid
 
 # Mathematical Formula
 For each face, the surface temperature T is calculated from:
@@ -44,8 +44,8 @@ where:
 - The temperature instantly adjusts to balance incoming and outgoing radiation
 - No subsurface temperatures are updated (only surface layer)
 """
-function update_temperature_zero_conductivity!(state::SingleAsteroidThermoPhysicalState)
-    for i_face in eachindex(state.problem.shape.faces)
+function update_temperature_zero_conductivity!(state::SingleLevelThermoPhysicalState)
+    for i_face in axes(state.temperature, 2)
         R_vis = state.problem.thermo_params.reflectance_vis[i_face]
         R_ir  = state.problem.thermo_params.reflectance_ir[i_face]
         ε     = state.problem.thermo_params.emissivity[i_face]
@@ -61,13 +61,13 @@ function update_temperature_zero_conductivity!(state::SingleAsteroidThermoPhysic
 end
 
 """
-    update_temperature!(state::SingleAsteroidThermoPhysicalState, Δt)
+    update_temperature!(state::SingleLevelThermoPhysicalState, Δt)
 
 Update the temperature distribution for the next time step by solving the 1D heat conduction equation.
 The solver method is determined by `state.solver_cache`, and special handling is applied for zero conductivity.
 
 # Arguments
-- `state::SingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid
+- `state::SingleLevelThermoPhysicalState` : Thermophysical simulation state for a single asteroid
 - `Δt::Real` : Time step [s]
 
 # Solver Selection
@@ -80,6 +80,12 @@ The function automatically selects the appropriate solver based on `state.solver
 - If thermal conductivity is zero, calls `update_temperature_zero_conductivity!` instead
 - The zero-conductivity case uses instantaneous radiative equilibrium
 
+# Notes
+- For a `HierarchicalSingleAsteroidThermoPhysicalState`, only the global-level temperature
+  is advanced; the sub-face states in `roughness_states` are left untouched. The global
+  faces are solved independently of their roughness models and serve as the smooth-surface
+  baseline for the same run.
+
 # Mathematical Background
 Solves the 1D heat conduction equation:
 ```
@@ -91,7 +97,7 @@ where α = k/(ρCₚ) is the thermal diffusivity.
 - `explicit_euler!`, `implicit_euler!`, `crank_nicolson!` for specific solver implementations
 - `update_temperature_zero_conductivity!` for the zero-conductivity case
 """
-function update_temperature!(state::SingleAsteroidThermoPhysicalState, Δt)
+function update_temperature!(state::SingleLevelThermoPhysicalState, Δt)
     # Handle zero-conductivity case
     if iszero(state.problem.thermo_params.conductivity)
         update_temperature_zero_conductivity!(state)
@@ -131,13 +137,13 @@ end
 
 
 """
-    explicit_euler!(state::SingleAsteroidThermoPhysicalState, Δt)
+    explicit_euler!(state::SingleLevelThermoPhysicalState, Δt)
 
 Solve the 1D heat conduction equation using the explicit (forward) Euler method.
 This method is conditionally stable and requires careful time step selection.
 
 # Arguments
-- `state::SingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid
+- `state::SingleLevelThermoPhysicalState` : Thermophysical simulation state for a single asteroid
 - `Δt::Real` : Time step [s]
 
 # Method Properties
@@ -169,7 +175,7 @@ The method is stable only when λ < 0.5. If this condition is violated, an error
 # Errors
 - Throws an error if λ ≥ 0.5 (stability violation)
 """
-function explicit_euler!(state::SingleAsteroidThermoPhysicalState, Δt)
+function explicit_euler!(state::SingleLevelThermoPhysicalState, Δt)
     T = state.temperature
     n_depth = size(T, 1)
     n_face = size(T, 2)
@@ -198,13 +204,13 @@ end
 
 
 """
-    implicit_euler!(state::SingleAsteroidThermoPhysicalState, Δt)
+    implicit_euler!(state::SingleLevelThermoPhysicalState, Δt)
 
 Solve the 1D heat conduction equation using the implicit (backward) Euler method.
 This method is unconditionally stable, allowing for larger time steps than explicit methods.
 
 # Arguments
-- `state::SingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid
+- `state::SingleLevelThermoPhysicalState` : Thermophysical simulation state for a single asteroid
 - `Δt::Real` : Time step [s]
 
 # Method Properties
@@ -242,7 +248,7 @@ Different boundary conditions modify the tridiagonal matrix:
 - `tridiagonal_matrix_algorithm!` for the solution algorithm
 - `update_upper_temperature!`, `update_lower_temperature!` for boundary conditions
 """
-function implicit_euler!(state::SingleAsteroidThermoPhysicalState, Δt)
+function implicit_euler!(state::SingleLevelThermoPhysicalState, Δt)
     T = state.temperature
     n_depth = size(T, 1)
     n_face = size(T, 2)
@@ -320,13 +326,13 @@ end
 
 
 """
-    crank_nicolson!(state::SingleAsteroidThermoPhysicalState, Δt)
+    crank_nicolson!(state::SingleLevelThermoPhysicalState, Δt)
 
 Solve the 1D heat conduction equation using the Crank-Nicolson method.
 This method combines the explicit and implicit Euler methods for improved accuracy.
 
 # Arguments
-- `state::SingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid
+- `state::SingleLevelThermoPhysicalState` : Thermophysical simulation state for a single asteroid
 - `Δt::Real` : Time step [s]
 
 # Method Properties
@@ -363,7 +369,7 @@ that includes information from the current time step.
 - `tridiagonal_matrix_algorithm!` for the solution algorithm
 - `implicit_euler!`, `explicit_euler!` for comparison with other methods
 """
-function crank_nicolson!(state::SingleAsteroidThermoPhysicalState, Δt)
+function crank_nicolson!(state::SingleLevelThermoPhysicalState, Δt)
     T = state.temperature
     n_depth = size(T, 1)
     n_face = size(T, 2)
@@ -448,7 +454,7 @@ end
 
 """
     tridiagonal_matrix_algorithm!(a, b, c, d, x)
-    tridiagonal_matrix_algorithm!(state::SingleAsteroidThermoPhysicalModel)
+    tridiagonal_matrix_algorithm!(state::SingleLevelThermoPhysicalState)
 
 Tridiagonal matrix algorithm to solve the heat conduction equation
 by the implicit (backward) Euler and Crank-Nicolson methods.
@@ -479,7 +485,7 @@ function tridiagonal_matrix_algorithm!(a, b, c, d, x)
     end
 end
 
-tridiagonal_matrix_algorithm!(state::SingleAsteroidThermoPhysicalState) = tridiagonal_matrix_algorithm!(state.solver_cache.a, state.solver_cache.b, state.solver_cache.c, state.solver_cache.d, state.solver_cache.x)
+tridiagonal_matrix_algorithm!(state::SingleLevelThermoPhysicalState) = tridiagonal_matrix_algorithm!(state.solver_cache.a, state.solver_cache.b, state.solver_cache.c, state.solver_cache.d, state.solver_cache.x)
 
 
 # ╔═══════════════════════════════════════════════════════════════════╗
@@ -487,7 +493,7 @@ tridiagonal_matrix_algorithm!(state::SingleAsteroidThermoPhysicalState) = tridia
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    update_upper_temperature!(state::SingleAsteroidThermoPhysicalState, i::Integer)
+    update_upper_temperature!(state::SingleLevelThermoPhysicalState, i::Integer)
 
 Update the temperature of the upper surface based on the boundary condition `state.problem.upper_boundary_condition`.
 
@@ -495,7 +501,7 @@ Update the temperature of the upper surface based on the boundary condition `sta
 - `state` : Thermophysical simulation state for a single asteroid
 - `i`    : Index of the face of the shape model
 """
-function update_upper_temperature!(state::SingleAsteroidThermoPhysicalState, i::Integer)
+function update_upper_temperature!(state::SingleLevelThermoPhysicalState, i::Integer)
 
     #### Radiation boundary condition ####
     if state.problem.upper_boundary_condition isa RadiationBoundaryCondition
@@ -567,12 +573,12 @@ end
 # ╚═══════════════════════════════════════════════════════════════════╝
 
 """
-    update_lower_temperature!(state::SingleAsteroidThermoPhysicalState)
+    update_lower_temperature!(state::SingleLevelThermoPhysicalState)
 
 Update the temperature at the lower boundary (deepest layer) based on the boundary condition.
 
 # Arguments
-- `state::SingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid
+- `state::SingleLevelThermoPhysicalState` : Thermophysical simulation state for a single asteroid
 
 # Boundary Conditions
 The function applies one of the following boundary conditions at the bottom of the computational domain:
@@ -592,7 +598,7 @@ The function applies one of the following boundary conditions at the bottom of t
 - For explicit Euler method, it directly updates the temperature vector
 - The lower boundary should be deep enough that the chosen condition doesn't affect surface temperatures
 """
-function update_lower_temperature!(state::SingleAsteroidThermoPhysicalState)
+function update_lower_temperature!(state::SingleLevelThermoPhysicalState)
 
     #### Insulation boundary condition ####
     if state.problem.lower_boundary_condition isa InsulationBoundaryCondition

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -7,6 +7,7 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
 - automatic preparation of the geometric data required for self-shadowing and self-heating
 - update_flux_sun! on the global level, compared against the plain ShapeModel result
 - update_flux_scat_single! / update_flux_rad_single! on the global level, likewise
+- update_temperature! on the global level, for all three solvers and for zero conductivity
 =#
 
 @testset "HierarchicalSingleAsteroidThermoPhysicalState" begin
@@ -285,5 +286,99 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
         @test all(state_hier.flux_scat .== 0.0)
         @test all(state_hier.flux_rad  .== 0.0)
         @test any(>(0), state_hier.flux_sun)  # the shape is lit, so the zeros are the flag's doing
+    end
+
+    @testset "update_temperature! (global level)" begin
+        # The global faces of a hierarchical state are solved independently of their roughness
+        # models, so after any number of steps they must match the plain ShapeModel exactly.
+        # A concave crater with self-heating exercises every flux term in the surface balance.
+        make_crater(; as_hierarchical) =
+            create_shape_crater(0.4, 0.1; Nx=8, Ny=8, as_hierarchical)
+
+        n_faces = length(make_crater(as_hierarchical=false).faces)
+        T₀ = repeat(reshape(range(200.0, 300.0; length=n_faces) |> collect, 1, n_faces),
+                    grid_params.n_depth)
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        Δt = 100.0  # λ = αΔt/Δz² ≈ 0.12 keeps the explicit Euler step stable
+        n_steps = 10
+
+        for algorithm in (CrankNicolson(), ImplicitEuler(), ExplicitEuler())
+            shape_plain = make_crater(as_hierarchical=false)
+            shape_hier  = make_crater(as_hierarchical=true)
+            add_roughness_models!(shape_hier, create_shape_crater(0.4, 0.1; Nx=4, Ny=4))
+
+            problem_plain = SingleAsteroidThermoPhysicalProblem(shape_plain, thermo_params, grid_params;
+                with_self_shadowing=false, with_self_heating=true)
+            problem_hier  = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+                with_self_shadowing=false, with_self_heating=true)
+
+            state_plain = AsteroidThermoPhysicalModels._build_single_state(problem_plain, algorithm)
+            state_hier  = AsteroidThermoPhysicalModels._build_single_state(problem_hier,  algorithm)
+            AsteroidThermoPhysicalModels.init_temperature!(state_plain, T₀)
+            AsteroidThermoPhysicalModels.init_temperature!(state_hier,  T₀)
+
+            for _ in 1:n_steps, state in (state_plain, state_hier)
+                AsteroidThermoPhysicalModels.update_flux_sun!(state, r☉)
+                AsteroidThermoPhysicalModels.update_flux_scat_single!(state)
+                AsteroidThermoPhysicalModels.update_flux_rad_single!(state)
+                AsteroidThermoPhysicalModels.update_temperature!(state, Δt)
+            end
+
+            # Global level matches the plain ShapeModel result exactly, and has actually moved
+            @test state_hier.temperature == state_plain.temperature
+            @test state_hier.temperature != T₀
+
+            # Sub-face states are not advanced by the global-level update
+            for (i, k) in enumerate(state_hier.face_roughness_indices)
+                k == 0 && continue
+                @test all(state_hier.roughness_states[k].temperature .== T₀[begin, i])
+            end
+        end
+    end
+
+    @testset "update_temperature! (global level, zero conductivity)" begin
+        # Zero conductivity replaces the solver by instantaneous radiative equilibrium at the
+        # surface, which is the one code path that used to reach for `shape.faces` directly.
+        thermo_params_k0 = ThermoParams(
+            conductivity    = 0.0,
+            density         = 1000.0,
+            heat_capacity   = 700.0,
+            reflectance_vis = 0.1,
+            reflectance_ir  = 0.0,
+            emissivity      = 0.9,
+        )
+
+        shape_plain = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
+        shape_hier  = create_shape_crater(0.4, 0.1; Nx=8, Ny=8, as_hierarchical=true)
+        add_roughness_models!(shape_hier, create_shape_crater(0.4, 0.1; Nx=4, Ny=4))
+
+        problem_plain = SingleAsteroidThermoPhysicalProblem(shape_plain, thermo_params_k0, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+        problem_hier  = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params_k0, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+
+        state_plain = AsteroidThermoPhysicalModels._build_single_state(problem_plain, CrankNicolson())
+        state_hier  = AsteroidThermoPhysicalModels._build_single_state(problem_hier,  CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_plain, 250.0)
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier,  250.0)
+
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        for state in (state_plain, state_hier)
+            AsteroidThermoPhysicalModels.update_flux_sun!(state, r☉)
+            AsteroidThermoPhysicalModels.update_flux_scat_single!(state)
+            AsteroidThermoPhysicalModels.update_flux_rad_single!(state)
+            AsteroidThermoPhysicalModels.update_temperature!(state, 100.0)
+        end
+
+        @test state_hier.temperature == state_plain.temperature
+
+        # Surface is in radiative equilibrium with the absorbed flux: εσT⁴ = F_abs
+        εσ = 0.9 * AsteroidThermoPhysicalModels.σ_SB
+        for i in axes(state_hier.temperature, 2)
+            F_abs = AsteroidThermoPhysicalModels.absorbed_energy_flux(
+                0.1, 0.0, state_hier.flux_sun[i], state_hier.flux_scat[i], state_hier.flux_rad[i])
+            @test state_hier.temperature[begin, i] ≈ (F_abs / εσ)^(1/4)
+        end
+        @test any(>(0), state_hier.temperature[begin, :])
     end
 end


### PR DESCRIPTION
## Summary

Phase 4 of surface roughness support (v0.3.0): make `update_temperature!` and the solvers beneath it accept a `HierarchicalSingleAsteroidThermoPhysicalState`. Follows #223 and #225.

- **Widen the solver signatures** (`src/heat_conduction.jl`): `update_temperature!`, `update_temperature_zero_conductivity!`, `explicit_euler!`, `implicit_euler!`, `crank_nicolson!`, `tridiagonal_matrix_algorithm!(state)`, `update_upper_temperature!`, and `update_lower_temperature!` now take `SingleLevelThermoPhysicalState` instead of `SingleAsteroidThermoPhysicalState`. The solvers touch only `temperature`, `solver_cache`, the flux vectors and the problem's parameters, all of which share their layout across the two state types, so no body changes are needed and no per-type dispatch is introduced.
- **Drop the one `shape.faces` access**: the zero-conductivity branch iterated `eachindex(state.problem.shape.faces)`; it now iterates `axes(state.temperature, 2)` like the other solvers.
- **Global level only.** Per the design decision of 2026-09-04, the global faces are solved independently of their roughness models and serve as the smooth-surface baseline for the same run; they are not overwritten by any sub-face aggregate. The sub-face states are left untouched until their own temperature update lands. The `update_temperature!` docstring records this.

## Test plan

- [x] New testset `update_temperature! (global level)` in `test/test_hierarchical_state.jl`: the same concave crater as a plain `ShapeModel` and as a `HierarchicalShapeModel`, stepped 10 times with self-heating for `CrankNicolson`, `ImplicitEuler`, and `ExplicitEuler`. Asserts bit-identical (`==`) global temperatures, that the temperature actually moved, and that every sub-face state still holds its initial value.
- [x] New testset `update_temperature! (global level, zero conductivity)`: covers the changed loop; asserts plain/hierarchical equality and that the surface sits at radiative equilibrium `εσT⁴ = F_abs`.
- [x] Full `Pkg.test()` passes locally (Julia 1.12.6). `heat_conduction_1D.jl`, `test_boundary_conditions.jl`, `TPM_zero-conductivity`, and the Ryugu/Didymos end-to-end tests cover the unchanged `SingleAsteroidThermoPhysicalState` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)