### PR TITLE
feat: illuminate the sub-faces of each roughness model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,10 @@ grid_params.Δz
   global-level flux updates (`update_flux_sun!`, `update_flux_scat_single!`,
   `update_flux_rad_single!`), and the global-level heat conduction (`update_temperature!`
   with all three solvers) support the new state. The global faces are solved independently
-  of their roughness models and serve as the smooth-surface baseline. Sub-face flux and
-  temperature updates land in later releases of the v0.3.0 series
+  of their roughness models and serve as the smooth-surface baseline. `update_flux_sun!` also
+  illuminates the sub-faces of every roughness model in its local frame, with self-shadowing
+  inside the roughness model, gated on the illumination of the parent global face. Sub-face
+  self-heating and temperature updates land in later releases of the v0.3.0 series
 
 ### Changed
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -246,21 +246,50 @@ end
 """
     update_flux_sun!(state::HierarchicalSingleAsteroidThermoPhysicalState, r☉::StaticVector{3})
 
-Update the direct solar irradiation flux on every global face of an asteroid with surface roughness.
+Update the direct solar irradiation flux on every global face and on every sub-face of an
+asteroid with surface roughness.
 
 # Arguments
 - `state::HierarchicalSingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid with surface roughness
 - `r☉::StaticVector{3}`     : Position vector from asteroid to Sun in body-fixed frame (NOT normalized) [m]
 
+# Algorithm
+1. Global level: identical to `SingleAsteroidThermoPhysicalState`, on `state.problem.shape.global_shape`.
+2. Sub-face level, for every global face that carries a roughness model:
+   - If the global face is not illuminated (facing away from the Sun, or shadowed by the global
+     topography), every one of its sub-faces is dark. A roughness model has no terrain beyond
+     its own rim, so without this gate a Sun below the local horizon could still light sub-faces
+     tilted towards it.
+   - Otherwise the Sun vector is rotated into the local frame of the face and the sub-faces are
+     illuminated by the same model as any `ShapeModel`, including self-shadowing within the
+     roughness model.
+
 # Notes
-- Only the global level (`state.problem.shape.global_shape`) is updated; the algorithm and
-  self-shadowing treatment are the same as for `SingleAsteroidThermoPhysicalState`.
-- The sub-face states in `state.roughness_states` are left untouched. Their illumination and
-  solar flux in the local frame of each roughness model will be handled by the sub-face flux
-  update.
+- The global level must be updated first: the sub-face gate reads `state.illuminated_faces`.
+- The transform to the local frame is a pure rotation, so `|r☉|` and hence the solar flux at
+  the asteroid are preserved.
 """
 function update_flux_sun!(state::HierarchicalSingleAsteroidThermoPhysicalState, r☉::StaticVector{3})
     _update_flux_sun!(state, state.problem.shape.global_shape, r☉)
+    _update_roughness_flux_sun!(state, r☉)
+end
+
+
+# Sub-face solar flux for every global face that carries a roughness model. See the docstring
+# of `update_flux_sun!` for the gate on the global illumination.
+function _update_roughness_flux_sun!(state::HierarchicalSingleAsteroidThermoPhysicalState, r☉::StaticVector{3})
+    shape = state.problem.shape
+    for (i, k) in enumerate(state.face_roughness_indices)
+        k == 0 && continue
+        rs = state.roughness_states[k]
+        if state.illuminated_faces[i]
+            r☉_local = transform_physical_vector_global_to_local(shape, i, r☉)
+            update_flux_sun!(rs, r☉_local)
+        else
+            rs.illuminated_faces .= false
+            rs.flux_sun          .= 0.0
+        end
+    end
 end
 
 """

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -73,13 +73,15 @@ function _build_single_state(
             [problem.thermo_params.reflectance_ir[i]],
             [problem.thermo_params.emissivity[i]],
         )
-        # TODO: Self-shadowing and self-heating inside a roughness model are the origin of
-        #       thermal beaming, so they must eventually be enabled here. They are kept off
-        #       until the sub-face flux calculations land, since enabling them also requires
-        #       the roughness model to carry a face visibility graph.
+        # Self-shadowing inside a roughness model is the origin of thermal beaming, so it is
+        # always on rather than inherited from the global problem: a roughness model without
+        # it has no physical meaning. The constructor builds the visibility graph and the
+        # maximum elevations on the roughness model, which is shared by all faces, once.
+        # TODO: Self-heating inside the roughness model is enabled together with the sub-face
+        #       scattering and thermal radiation updates.
         mini_prob = SingleAsteroidThermoPhysicalProblem(
             roughness_shape, tp_sub, problem.grid_params;
-            with_self_shadowing = false,
+            with_self_shadowing = true,
             with_self_heating   = false,
             upper_boundary_condition = problem.upper_boundary_condition,
             lower_boundary_condition = problem.lower_boundary_condition,

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -6,6 +6,8 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
 - init_temperature! for HierarchicalSingleAsteroidThermoPhysicalState (Real and AbstractMatrix)
 - automatic preparation of the geometric data required for self-shadowing and self-heating
 - update_flux_sun! on the global level, compared against the plain ShapeModel result
+- update_flux_sun! on the sub-face level: gate on the global illumination, consistency with a
+  standalone roughness model, and a near-flat roughness model reproducing the parent face
 - update_flux_scat_single! / update_flux_rad_single! on the global level, likewise
 - update_temperature! on the global level, for all three solvers and for zero conductivity
 =#
@@ -197,13 +199,122 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
                 end
                 @test any(state_hier.illuminated_faces) && !all(state_hier.illuminated_faces)
 
-                # Sub-face states are not touched by the global-level update
-                for rs in state_hier.roughness_states
+                # Sub-faces of a dark global face are all dark (the sub-face level is covered
+                # in detail by the dedicated testsets below)
+                for (i, k) in enumerate(state_hier.face_roughness_indices)
+                    k == 0 && continue
+                    state_hier.illuminated_faces[i] && continue
+                    rs = state_hier.roughness_states[k]
                     @test !any(rs.illuminated_faces)
                     @test all(rs.flux_sun .== 0.0)
                 end
             end
         end
+    end
+
+    @testset "update_flux_sun! (sub-face level)" begin
+        # For a lit global face, the sub-faces must be exactly what a standalone state of the
+        # roughness model gives for the Sun vector rotated into the local frame. For a dark
+        # global face, every sub-face must be dark regardless of the local geometry: the
+        # roughness model has no terrain beyond its rim, so a Sun just below the local horizon
+        # would otherwise light sub-faces tilted towards it.
+        path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
+        crater   = create_shape_crater(0.4, 0.1; Nx=6, Ny=6)
+
+        shape_hier = load_shape_obj(path_obj; as_hierarchical=true)
+        add_roughness_models!(shape_hier, crater)
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=true, with_self_heating=false)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+
+        # A standalone state of the same roughness model, illuminated with the same model
+        problem_alone = SingleAsteroidThermoPhysicalProblem(crater, thermo_params, grid_params;
+            with_self_shadowing=true, with_self_heating=false)
+        state_alone = AsteroidThermoPhysicalModels._build_single_state(problem_alone, CrankNicolson())
+
+        # Sub-face self-shadowing is always on, so the roughness model carries its geometry
+        @test !isnothing(crater.face_visibility_graph)
+        @test !isnothing(crater.face_max_elevations)
+
+        r☉s = [
+            SVector(1.0, 0.0, 0.0) * AsteroidThermoPhysicalModels.au2m,
+            SVector(0.3, -0.5, 0.8) * 1.2AsteroidThermoPhysicalModels.au2m,
+        ]
+        for r☉ in r☉s
+            AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+
+            n_lit_parents = n_dark_parents = 0
+            for (i, k) in enumerate(state_hier.face_roughness_indices)
+                rs = state_hier.roughness_states[k]
+                if state_hier.illuminated_faces[i]
+                    n_lit_parents += 1
+                    r☉_local = transform_physical_vector_global_to_local(shape_hier, i, r☉)
+                    @test norm(r☉_local) ≈ norm(r☉)   # pure rotation: solar flux is preserved
+                    AsteroidThermoPhysicalModels.update_flux_sun!(state_alone, r☉_local)
+                    @test rs.illuminated_faces == state_alone.illuminated_faces
+                    @test rs.flux_sun          == state_alone.flux_sun
+                    @test any(rs.illuminated_faces)
+                else
+                    n_dark_parents += 1
+                    @test !any(rs.illuminated_faces)
+                    @test all(rs.flux_sun .== 0.0)
+                end
+            end
+            # Both branches of the gate were exercised
+            @test n_lit_parents > 0 && n_dark_parents > 0
+        end
+    end
+
+    @testset "update_flux_sun! (near-flat roughness reproduces the parent face)" begin
+        # With a roughness model that is flat to 1e-6, every sub-face has the normal of its
+        # parent face, so its solar flux must equal the parent's. This pins the rotation into
+        # the local frame: a wrong rotation would change cos θ and show up here.
+        shape_hier = load_shape_obj(joinpath(@__DIR__, "shape", "icosahedron.obj"); as_hierarchical=true)
+        add_roughness_models!(shape_hier, create_shape_crater(0.4, 1e-6; Nx=4, Ny=4))
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+
+        r☉ = SVector(0.3, -0.2, 0.9) * AsteroidThermoPhysicalModels.au2m
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+
+        # The residual tilt of the sub-face normals (~1e-6) is an absolute error in cos θ, so
+        # compare against the flux at normal incidence rather than relatively: at grazing
+        # incidence the parent flux itself is tiny and a relative tolerance is ill-conditioned.
+        # A wrong rotation would produce O(1) differences and is still caught.
+        r̂☉ = normalize(r☉)
+        F☉ = AsteroidThermoPhysicalModels.SOLAR_CONST / (norm(r☉) * AsteroidThermoPhysicalModels.m2au)^2
+        n_checked = 0
+        for (i, k) in enumerate(state_hier.face_roughness_indices)
+            rs = state_hier.roughness_states[k]
+            if state_hier.illuminated_faces[i]
+                shape_hier.global_shape.face_normals[i] ⋅ r̂☉ < 1e-3 && continue  # grazing: skip
+                n_checked += 1
+                @test all(rs.illuminated_faces)
+                @test all(isapprox.(rs.flux_sun, state_hier.flux_sun[i]; atol=1e-5 * F☉))
+            else
+                @test all(rs.flux_sun .== 0.0)
+            end
+        end
+        @test n_checked > 0
+    end
+
+    @testset "update_flux_sun! (partial roughness)" begin
+        # Faces without a roughness model are skipped; the one with it is updated
+        shape_hier = load_shape_obj(joinpath(@__DIR__, "shape", "icosahedron.obj"); as_hierarchical=true)
+        add_roughness_models!(shape_hier, create_shape_crater(0.4, 0.1; Nx=4, Ny=4), 1)
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+
+        # Point the Sun along the normal of face 1 so that it is certainly lit
+        n̂₁ = shape_hier.global_shape.face_normals[1]
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, n̂₁ * AsteroidThermoPhysicalModels.au2m)
+
+        @test state_hier.illuminated_faces[1]
+        @test length(state_hier.roughness_states) == 1
+        @test all(state_hier.roughness_states[1].illuminated_faces)
+        @test all(>(0), state_hier.roughness_states[1].flux_sun)
     end
 
     @testset "update_flux_sun! requires face_visibility_graph for self-shadowing" begin


### PR DESCRIPTION
## Summary

First step on the sub-face level of surface roughness. `update_flux_sun!` on a `HierarchicalSingleAsteroidThermoPhysicalState` now updates both levels: after the global faces (#223), every global face that carries a roughness model has its Sun vector rotated into the local frame of the face and its sub-faces illuminated by the same model as any `ShapeModel`, self-shadowing inside the roughness model included.

```julia
function update_flux_sun!(state::HierarchicalSingleAsteroidThermoPhysicalState, r☉)
    _update_flux_sun!(state, state.problem.shape.global_shape, r☉)   # #223
    _update_roughness_flux_sun!(state, r☉)                           # this PR
end
```

### Design decisions

These were settled in the design note before implementation.

- **Gate on the global illumination.** A global face that is dark — by orientation, or shadowed by the global topography — darkens all of its sub-faces. A roughness model has no terrain beyond its own rim, so without this gate a Sun just below the local horizon still lights sub-faces tilted towards it: with the crater used in the tests, 1 of 128 sub-faces lights up at 5° below the horizon. For a lit global face, the sub-faces are judged individually in the local frame.
- **Sub-face self-shadowing is always on.** It is the origin of thermal beaming, so a roughness model without it has no physical meaning; the flag is hardcoded rather than inherited from the global problem. The constructor builds the visibility graph and the maximum elevations on the roughness model once (it is shared by all faces).
- **One entry point.** The sub-face update lives inside `update_flux_sun!` rather than in a separate function, so there is no way to call one level without the other.
- **Coupling is one-way, global → sub-face.** The global level stays the smooth-surface baseline; sub-faces read from it and never write to it. External irradiation of the sub-faces from neighbouring global faces (`flux_scat`, `flux_rad` weighted by the sky view factor) comes with the sub-face self-heating step.

## Test plan

- [x] **Consistency**: for a lit global face, the sub-faces equal exactly what a standalone state of the roughness model gives for the rotated Sun vector; for a dark global face, every sub-face is dark. The icosahedron guarantees both branches of the gate are exercised.
- [x] **Rotation**: with a roughness model flat to 1e-6, every sub-face carries the normal of its parent, so its flux must equal the parent's. A wrong rotation into the local frame shows up as an O(1) difference. The residual tilt is an absolute error in cos θ, so the comparison uses an absolute tolerance against the flux at normal incidence and skips grazing faces, where a relative tolerance is ill-conditioned.
- [x] **Partial roughness**: faces without a model are skipped.
- [x] The global-level test from #223 now asserts only that dark parents have dark sub-faces, since sub-faces are no longer left untouched. All other existing tests pass unchanged, including the #225 / #226 assertions that sub-face scattering, radiation and temperature are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
