### PR TITLE
feat: compute self-heating inside each roughness model and its external irradiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,8 +95,13 @@ grid_params.Δz
   with all three solvers) support the new state. The global faces are solved independently
   of their roughness models and serve as the smooth-surface baseline. `update_flux_sun!` also
   illuminates the sub-faces of every roughness model in its local frame, with self-shadowing
-  inside the roughness model, gated on the illumination of the parent global face. Sub-face
-  self-heating and temperature updates land in later releases of the v0.3.0 series
+  inside the roughness model, gated on the illumination of the parent global face.
+  `update_flux_scat_single!` and `update_flux_rad_single!` compute the self-heating inside
+  each roughness model and add the flux the parent face receives from the other global faces,
+  distributed over the sub-faces by their sky view factor. Self-shadowing and self-heating
+  inside a roughness model are always on; the problem's `with_self_heating` governs the global
+  faces and, through them, the external irradiation of the sub-faces. Sub-face temperature
+  updates land in a later release of the v0.3.0 series
 
 ### Changed
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -403,20 +403,56 @@ end
 """
     update_flux_scat_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
 
-Update flux of scattered sunlight between the global faces of an asteroid with surface roughness,
-only considering single scattering.
+Update flux of scattered sunlight on every global face and on every sub-face of an asteroid with
+surface roughness, only considering single scattering.
 
 # Arguments
 - `state` : Thermophysical simulation state for a single asteroid with surface roughness
 
+# Algorithm
+1. Global level: identical to `SingleAsteroidThermoPhysicalState`, on `state.problem.shape.global_shape`.
+2. Sub-face level, for every global face that carries a roughness model:
+   - scattering between the sub-faces of the roughness model, from the sub-face `flux_sun`
+     computed by `update_flux_sun!`;
+   - plus the scattered light the parent global face receives from the other global faces,
+     distributed over the sub-faces by their sky view factor (see `_add_external_irradiance!`).
+
 # Notes
-- Only the global level (`state.problem.shape.global_shape`) is updated, from the global-level
-  `flux_sun` computed by `update_flux_sun!`.
-- The sub-face states in `state.roughness_states` are left untouched. Scattering within each
-  roughness model will be handled by the sub-face flux update.
+- The global level must be updated first: the external term reads `state.flux_scat`.
 """
 function update_flux_scat_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
     _update_flux_scat_single!(state, state.problem.shape.global_shape)
+    for (i, k) in enumerate(state.face_roughness_indices)
+        k == 0 && continue
+        rs = state.roughness_states[k]
+        _update_flux_scat_single!(rs, rs.problem.shape)
+        _add_external_irradiance!(rs.flux_scat, rs.problem.shape, state.flux_scat[i])
+    end
+end
+
+
+"""
+    _add_external_irradiance!(flux_sub, shape::ShapeModel, flux_parent)
+
+Add to the sub-face fluxes `flux_sub` of a roughness model `shape` the flux `flux_parent` that
+its parent global face receives from the other global faces.
+
+The parent flux is taken as isotropic over the parent's sky hemisphere, so sub-face `j`
+receives it in proportion to its sky view factor `1 − Σₖ fⱼₖ` — the part of the hemisphere not
+covered by the other sub-faces. A sub-face on the floor of a deep crater therefore receives
+less than one on the rim, and a flat roughness model receives exactly the parent flux. On a
+convex body the parent flux is zero and nothing is added.
+
+This is the isotropic limit of a directional treatment in which each neighbouring global
+face radiates with its own rough-surface beaming; it is the level implemented for now.
+"""
+function _add_external_irradiance!(flux_sub::AbstractVector, shape::ShapeModel, flux_parent::Real)
+    iszero(flux_parent) && return
+    graph = shape.face_visibility_graph
+    for j in eachindex(shape.faces)
+        f_sky = max(0.0, 1 - sum(get_view_factors(graph, j)))
+        flux_sub[j] += f_sky * flux_parent
+    end
 end
 
 """
@@ -485,20 +521,34 @@ end
 """
     update_flux_rad_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
 
-Update flux of absorption of thermal radiation between the global faces of an asteroid with
-surface roughness.
+Update flux of absorption of thermal radiation on every global face and on every sub-face of an
+asteroid with surface roughness.
 
 # Arguments
 - `state` : Thermophysical simulation state for a single asteroid with surface roughness
 
+# Algorithm
+1. Global level: identical to `SingleAsteroidThermoPhysicalState`, on `state.problem.shape.global_shape`.
+2. Sub-face level, for every global face that carries a roughness model:
+   - radiative exchange between the sub-faces of the roughness model, from the sub-face
+     surface temperatures;
+   - plus the thermal radiation the parent global face receives from the other global faces,
+     distributed over the sub-faces by their sky view factor (see `_add_external_irradiance!`).
+
 # Notes
-- Only the global level (`state.problem.shape.global_shape`) is updated, from the global-level
-  surface temperatures.
-- The sub-face states in `state.roughness_states` are left untouched. Radiative exchange within
-  each roughness model will be handled by the sub-face flux update.
+- The global level must be updated first: the external term reads `state.flux_rad`.
+- The global level is computed from the smooth-surface temperatures of the global faces, so
+  the radiation a sub-face receives from a neighbouring rough face carries the neighbour's
+  smooth temperature rather than its rough-surface emission.
 """
 function update_flux_rad_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
     _update_flux_rad_single!(state, state.problem.shape.global_shape)
+    for (i, k) in enumerate(state.face_roughness_indices)
+        k == 0 && continue
+        rs = state.roughness_states[k]
+        _update_flux_rad_single!(rs, rs.problem.shape)
+        _add_external_irradiance!(rs.flux_rad, rs.problem.shape, state.flux_rad[i])
+    end
 end
 
 """

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -73,16 +73,16 @@ function _build_single_state(
             [problem.thermo_params.reflectance_ir[i]],
             [problem.thermo_params.emissivity[i]],
         )
-        # Self-shadowing inside a roughness model is the origin of thermal beaming, so it is
-        # always on rather than inherited from the global problem: a roughness model without
-        # it has no physical meaning. The constructor builds the visibility graph and the
+        # Self-shadowing and self-heating inside a roughness model are the origin of thermal
+        # beaming, so both are always on rather than inherited from the global problem: a
+        # roughness model without them has no physical meaning. The global problem's
+        # `with_self_heating` governs the global faces only, and through them the external
+        # irradiation of the sub-faces. The constructor builds the visibility graph and the
         # maximum elevations on the roughness model, which is shared by all faces, once.
-        # TODO: Self-heating inside the roughness model is enabled together with the sub-face
-        #       scattering and thermal radiation updates.
         mini_prob = SingleAsteroidThermoPhysicalProblem(
             roughness_shape, tp_sub, problem.grid_params;
             with_self_shadowing = true,
-            with_self_heating   = false,
+            with_self_heating   = true,
             upper_boundary_condition = problem.upper_boundary_condition,
             lower_boundary_condition = problem.lower_boundary_condition,
         )

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -9,6 +9,9 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
 - update_flux_sun! on the sub-face level: gate on the global illumination, consistency with a
   standalone roughness model, and a near-flat roughness model reproducing the parent face
 - update_flux_scat_single! / update_flux_rad_single! on the global level, likewise
+- update_flux_scat_single! / update_flux_rad_single! on the sub-face level: self-heating inside
+  the roughness model, the external irradiation from the other global faces, and its absence
+  when the global self-heating is off
 - update_temperature! on the global level, for all three solvers and for zero conductivity
 =#
 
@@ -374,10 +377,137 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
         @test any(>(0), state_hier.flux_scat)
         @test any(>(0), state_hier.flux_rad)
 
-        # Sub-face states are not touched by the global-level update
+        # Sub-faces are updated as well (covered in detail by the dedicated testsets below)
         for rs in state_hier.roughness_states
-            @test all(rs.flux_scat .== 0.0)
-            @test all(rs.flux_rad  .== 0.0)
+            @test any(>(0), rs.flux_rad)
+        end
+    end
+
+    @testset "update_flux_scat_single! / update_flux_rad_single! (sub-face level)" begin
+        # Self-heating inside the roughness model must be exactly what a standalone state of
+        # the roughness model gives, and the flux the parent receives from the other global
+        # faces must be added on top, weighted by each sub-face's sky view factor. A concave
+        # global crater makes the parent fluxes non-zero; a roughness crater makes the
+        # intra-model exchange non-zero.
+        crater = create_shape_crater(0.4, 0.1; Nx=6, Ny=6)
+        shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8, as_hierarchical=true)
+        add_roughness_models!(shape_hier, crater)
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+
+        # Self-heating inside the roughness model is always on
+        @test all(rs.problem.with_self_heating for rs in state_hier.roughness_states)
+        @test !isnothing(crater.face_visibility_graph)
+
+        # Standalone state of the same roughness model, with the same flags as the sub-states
+        problem_alone = SingleAsteroidThermoPhysicalProblem(crater, thermo_params, grid_params;
+            with_self_shadowing=true, with_self_heating=true)
+        state_alone = AsteroidThermoPhysicalModels._build_single_state(problem_alone, CrankNicolson())
+
+        # Vary the temperature from face to face so the radiation term is not degenerate
+        n_faces = length(shape_hier.global_shape.faces)
+        T₀ = repeat(reshape(range(200.0, 300.0; length=n_faces) |> collect, 1, n_faces), grid_params.n_depth)
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier, T₀)
+
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+        AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
+        AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
+
+        # The parent fluxes are non-zero somewhere, so the external term is exercised
+        @test any(>(0), state_hier.flux_scat)
+        @test any(>(0), state_hier.flux_rad)
+
+        # Sky view factor of each sub-face of the (shared) roughness model
+        f_sky = [max(0.0, 1 - sum(get_view_factors(crater.face_visibility_graph, j)))
+                 for j in eachindex(crater.faces)]
+        @test all(0 .<= f_sky .<= 1)
+        @test any(<(1), f_sky)   # the crater walls do hide part of the sky
+
+        n_checked = 0
+        for (i, k) in enumerate(state_hier.face_roughness_indices)
+            rs = state_hier.roughness_states[k]
+            state_hier.illuminated_faces[i] || continue
+            n_checked += 1
+
+            # Standalone: same illumination and temperature, self-heating inside the model only
+            r☉_local = transform_physical_vector_global_to_local(shape_hier, i, r☉)
+            AsteroidThermoPhysicalModels.init_temperature!(state_alone, T₀[begin, i])
+            AsteroidThermoPhysicalModels.update_flux_sun!(state_alone, r☉_local)
+            AsteroidThermoPhysicalModels.update_flux_scat_single!(state_alone)
+            AsteroidThermoPhysicalModels.update_flux_rad_single!(state_alone)
+
+            @test rs.flux_scat ≈ state_alone.flux_scat .+ f_sky .* state_hier.flux_scat[i]
+            @test rs.flux_rad  ≈ state_alone.flux_rad  .+ f_sky .* state_hier.flux_rad[i]
+        end
+        @test n_checked > 0
+    end
+
+    @testset "global self-heating off removes the external term only" begin
+        # With `with_self_heating = false` on the global problem, the parent fluxes are zero
+        # and the sub-faces receive nothing from outside — but the self-heating inside each
+        # roughness model is still computed. This is what makes an on/off comparison of the
+        # global self-heating isolate the external contribution.
+        crater = create_shape_crater(0.4, 0.1; Nx=6, Ny=6)
+        shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8, as_hierarchical=true)
+        add_roughness_models!(shape_hier, crater)
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier, 250.0)
+
+        problem_alone = SingleAsteroidThermoPhysicalProblem(crater, thermo_params, grid_params;
+            with_self_shadowing=true, with_self_heating=true)
+        state_alone = AsteroidThermoPhysicalModels._build_single_state(problem_alone, CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_alone, 250.0)
+
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+        AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
+        AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
+
+        @test all(state_hier.flux_scat .== 0.0)
+        @test all(state_hier.flux_rad  .== 0.0)
+
+        for (i, k) in enumerate(state_hier.face_roughness_indices)
+            rs = state_hier.roughness_states[k]
+            state_hier.illuminated_faces[i] || continue
+            AsteroidThermoPhysicalModels.update_flux_sun!(state_alone, transform_physical_vector_global_to_local(shape_hier, i, r☉))
+            AsteroidThermoPhysicalModels.update_flux_scat_single!(state_alone)
+            AsteroidThermoPhysicalModels.update_flux_rad_single!(state_alone)
+            @test rs.flux_scat == state_alone.flux_scat
+            @test rs.flux_rad  == state_alone.flux_rad
+            @test any(>(0), rs.flux_rad)   # the crater does heat itself
+        end
+    end
+
+    @testset "near-flat roughness receives exactly the parent flux from outside" begin
+        # A flat roughness model has no walls (sky view factor 1) and no exchange between its
+        # own faces, so each sub-face must end up with exactly the parent's flux.
+        shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8, as_hierarchical=true)
+        add_roughness_models!(shape_hier, create_shape_crater(0.4, 1e-6; Nx=4, Ny=4))
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier, 250.0)
+
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+        AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
+        AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
+
+        # The view factors of a model flat to 1e-6 are ~1e-11 rather than zero, so the exchange
+        # between its own faces leaves a residual of ~1e-10 W/m². Compare with an absolute
+        # tolerance scaled by the largest parent flux: a relative one would fail on parents
+        # whose flux is exactly zero.
+        atol_scat = 1e-6 * maximum(state_hier.flux_scat)
+        atol_rad  = 1e-6 * maximum(state_hier.flux_rad)
+        @test atol_scat > 0 && atol_rad > 0
+        for (i, k) in enumerate(state_hier.face_roughness_indices)
+            rs = state_hier.roughness_states[k]
+            @test all(isapprox.(rs.flux_scat, state_hier.flux_scat[i]; atol=atol_scat))
+            @test all(isapprox.(rs.flux_rad,  state_hier.flux_rad[i];  atol=atol_rad))
         end
     end
 


### PR DESCRIPTION
## Summary

Sub-face self-heating. `update_flux_scat_single!` and `update_flux_rad_single!` on a `HierarchicalSingleAsteroidThermoPhysicalState` now update both levels, the same way `update_flux_sun!` does since #227:

```julia
function update_flux_rad_single!(state::HierarchicalSingleAsteroidThermoPhysicalState)
    _update_flux_rad_single!(state, state.problem.shape.global_shape)     # #225
    for (i, k) in enumerate(state.face_roughness_indices)                 # this PR
        k == 0 && continue
        rs = state.roughness_states[k]
        _update_flux_rad_single!(rs, rs.problem.shape)                          # inside the crater
        _add_external_irradiance!(rs.flux_rad, rs.problem.shape, state.flux_rad[i])   # from outside
    end
end
```

Two contributions per roughness model:

- **Inside the crater** — scattering and radiative exchange between the sub-faces, through the shared implementation from #225 applied to the sub-state. This is the origin of thermal beaming.
- **From outside** — the flux the parent global face receives from the other global faces, taken as isotropic over the parent's sky hemisphere and distributed over the sub-faces by their **sky view factor** `1 − Σₖ fⱼₖ`, the part of the hemisphere not covered by the other sub-faces. A sub-face on the floor of a deep crater receives less than one on the rim; a flat roughness model receives exactly the parent flux; on a convex body nothing is added.

### Design decisions

Settled in the design note before implementation.

- **Self-heating inside a roughness model is always on**, like its self-shadowing since #227: a roughness model without it has no physical meaning. The problem's `with_self_heating` governs the global faces only and, through them, the external irradiation of the sub-faces — so switching it off isolates the external contribution while each crater still heats itself.
- **The external term is the isotropic limit of a directional treatment** in which each neighbouring global face radiates with its own rough-surface beaming (its directional emission integrated over its sub-faces, received through the local horizon of each sub-face). That treatment factorises the emitter and receiver sides and is a later step; the term lives in one function (`_add_external_irradiance!`) so it can be swapped in.
- **Contributions are not stored separately.** Both are accumulated into `flux_scat` / `flux_rad`, so the heat-conduction solver and `absorbed_energy_flux` work unchanged. The external contribution is measured by comparing runs with the global self-heating on and off.
- **Coupling stays one-way, global → sub-face.** The external term reads the parent's smooth-surface flux and never writes back; the global level remains the baseline. A sub-face therefore receives a rough neighbour's radiation at the neighbour's smooth temperature — a known approximation, recorded in the docstring.

## Test plan

On a concave global crater carrying a roughness crater, so that both the parent fluxes and the exchange inside the model are non-zero:

- [x] Each sub-face flux equals the standalone roughness-model result plus the parent flux weighted by the sub-face's sky view factor; the sky view factors lie in [0, 1] and some are < 1 (the walls do hide sky).
- [x] With the global self-heating off, the parent fluxes vanish and the sub-faces equal the standalone result exactly, while the crater still heats itself.
- [x] A roughness model flat to 1e-6 receives exactly the parent flux from outside. Its view factors are ~1e-11 rather than zero, so the comparison uses an absolute tolerance scaled by the largest parent flux — a relative one fails on parents whose flux is exactly zero.
- [x] The #225 global-level test now asserts that sub-faces are updated rather than untouched. The #226 assertion that sub-face temperatures are untouched still holds; all other tests pass unchanged, including the #228 guards (the sub-problem's `with_self_heating = true` exercises them on the roughness model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
