### PR TITLE
fix: make `flux_rad` the incident irradiance, without the emitter's reflectance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,13 @@ grid_params.Δz
 
 ### Fixed
 
+- **`flux_rad` carried the emitter's thermal-infrared reflectance.** The self-heating and
+  mutual-heating thermal radiation terms multiplied the emission of the source face by
+  `1 − R_ir` of the *source*, on top of the `1 − R_ir` of the *receiving* face applied by the
+  surface boundary condition, so with a non-zero `R_ir` the absorbed thermal radiation was
+  counted short by a factor `1 − R_ir`. `flux_rad` is now the incident irradiance, like
+  `flux_sun` and `flux_scat`, and the receiving face's reflectance is applied exactly once.
+  No change for the default `R_ir = 0`
 - **Self-heating silently did nothing without a face visibility graph.** When a shape was
   loaded without `with_face_visibility=true`, `with_self_heating = true` was accepted but the
   scattered-light and thermal-radiation flux updates returned early and the re-absorption

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -481,7 +481,11 @@ end
 # ║                Energy flux: Thermal radiation                     ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
-# Shared implementation of the thermal-radiation absorption update for the faces of `shape`.
+# Shared implementation of the thermal-radiation update for the faces of `shape`. `flux_rad`
+# is the irradiance incident on each face from the others — like `flux_sun` and `flux_scat`,
+# it carries no absorptivity: the receiving face's `1 − R_ir` is applied where the flux is
+# absorbed (surface boundary condition, `absorbed_energy_flux`) and its `R_ir` where the
+# reflected part is emitted (`update_thermal_force!`).
 function _update_flux_rad_single!(state::SingleLevelThermoPhysicalState, shape::ShapeModel)
     state.problem.with_self_heating == false && return
     _require_face_visibility_graph(shape, "with_self_heating")
@@ -494,11 +498,12 @@ function _update_flux_rad_single!(state::SingleLevelThermoPhysicalState, shape::
         view_factors = get_view_factors(shape.face_visibility_graph, i)
 
         for (j, fᵢⱼ) in zip(visible_indices, view_factors)
-            ε    = state.problem.thermo_params.emissivity[j]
-            R_ir = state.problem.thermo_params.reflectance_ir[j]
-            Tⱼ   = state.temperature[begin, j]
+            εⱼ = state.problem.thermo_params.emissivity[j]
+            Tⱼ = state.temperature[begin, j]
 
-            state.flux_rad[i] += ε * σ_SB * (1 - R_ir) * fᵢⱼ * Tⱼ^4
+            # Irradiance on i from the Lambertian emission of j: Eⱼ Aⱼ Fⱼᵢ / Aᵢ = Eⱼ Fᵢⱼ by
+            # reciprocity, with Fᵢⱼ the view factor stored for face i
+            state.flux_rad[i] += εⱼ * σ_SB * fᵢⱼ * Tⱼ^4
         end
     end
 end
@@ -507,8 +512,11 @@ end
 """
     update_flux_rad_single!(state::SingleAsteroidThermoPhysicalState)
 
-Update flux of absorption of thermal radiation from surrounding surface.
-Single radiation-absorption is only considered, assuming albedo is close to zero at thermal infrared wavelength.
+Update the flux of thermal radiation incident on each face from the surrounding surface.
+
+Only the direct emission of the other faces is counted (single bounce); thermal radiation they
+reflect is neglected. `flux_rad` is an incident flux, like `flux_sun` and `flux_scat`: the
+thermal-infrared reflectance of the receiving face is applied where the flux is absorbed.
 
 # Arguments
 - `state` : Thermophysical simulation state for a single asteroid
@@ -617,16 +625,15 @@ function mutual_heating!(state::BinaryAsteroidThermoPhysicalState, r₁₂, R₂
                 ε₂     = thermo_params2.emissivity[j]
                 R_vis₁ = thermo_params1.reflectance_vis[i]
                 R_vis₂ = thermo_params2.reflectance_vis[j]
-                R_ir₁  = thermo_params1.reflectance_ir[i]
-                R_ir₂  = thermo_params2.reflectance_ir[j]
 
                 ## Mutual heating by scattered light
                 state.primary.flux_scat[i] += f₁₂ * R_vis₂ * state.secondary.flux_sun[j]
                 state.secondary.flux_scat[j] += f₂₁ * R_vis₁ * state.primary.flux_sun[i]
 
-                ## Mutual heating by thermal radiation
-                state.primary.flux_rad[i] += ε₂ * σ_SB * (1 - R_ir₂) * f₁₂ * T₂^4
-                state.secondary.flux_rad[j] += ε₁ * σ_SB * (1 - R_ir₁) * f₂₁ * T₁^4
+                ## Mutual heating by thermal radiation (incident flux; the receiving face's
+                ## thermal-infrared reflectance is applied where the flux is absorbed)
+                state.primary.flux_rad[i] += ε₂ * σ_SB * f₁₂ * T₂^4
+                state.secondary.flux_rad[j] += ε₁ * σ_SB * f₂₁ * T₁^4
             end
         end
     end

--- a/test/thermal_radiation.jl
+++ b/test/thermal_radiation.jl
@@ -7,6 +7,7 @@ This test validates:
 - Stefan-Boltzmann law implementation
 - View factor calculations for thermal radiation exchange
 - Self-heating effects between asteroid surface elements
+- flux_rad being the incident irradiance, independent of the thermal-infrared reflectance
 =#
 
 @testset "thermal_radiation" begin
@@ -110,4 +111,76 @@ This test validates:
     @test AsteroidThermoPhysicalModels.thermal_radiance(shape, emissivities, temperatures, obs_east)  ≈ 19.89394442347112
     @test AsteroidThermoPhysicalModels.thermal_radiance(shape, emissivities, temperatures, obs_above) ≈ 18.01010231251351
     @test AsteroidThermoPhysicalModels.thermal_radiance(shape, emissivities, temperatures, obs_west)  ≈ 12.406927167050457
+
+    ######## flux_rad is the incident irradiance ########
+
+    @testset "flux_rad is independent of R_ir" begin
+        # The thermal radiation a face receives from its neighbours is their emission ε σ T⁴
+        # weighted by the view factor. The receiving face's reflectance belongs to the surface
+        # boundary condition, not to flux_rad — so flux_rad must not change with R_ir at all.
+        # A concave crater makes the exchange non-zero; a temperature gradient makes a wrong
+        # face index visible.
+        grid_params = GridParams(; z_max=0.1, n_depth=10)
+        make_state(R_ir) = begin
+            thermo_params = ThermoParams(conductivity=0.1, density=1000.0, heat_capacity=700.0,
+                                         reflectance_vis=0.1, reflectance_ir=R_ir, emissivity=0.9)
+            shape   = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
+            problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
+                with_self_shadowing=false, with_self_heating=true)
+            state   = AsteroidThermoPhysicalModels._build_single_state(problem, CrankNicolson())
+            n_faces = length(shape.faces)
+            T₀ = repeat(reshape(range(200.0, 300.0; length=n_faces) |> collect, 1, n_faces), grid_params.n_depth)
+            AsteroidThermoPhysicalModels.init_temperature!(state, T₀)
+            AsteroidThermoPhysicalModels.update_flux_rad_single!(state)
+            state
+        end
+        state0 = make_state(0.0)
+        state3 = make_state(0.3)
+
+        @test any(>(0), state0.flux_rad)
+        @test state3.flux_rad == state0.flux_rad
+
+        # Explicit formula: flux_rad[i] = Σⱼ εⱼ σ Tⱼ⁴ Fᵢⱼ over the faces visible from i
+        shape = state3.problem.shape
+        σ = AsteroidThermoPhysicalModels.σ_SB
+        for i in eachindex(shape.faces)
+            js = get_visible_face_indices(shape.face_visibility_graph, i)
+            fs = get_view_factors(shape.face_visibility_graph, i)
+            expected = sum(0.9 * σ * state3.temperature[begin, j]^4 * f for (j, f) in zip(js, fs); init=0.0)
+            @test state3.flux_rad[i] ≈ expected
+        end
+
+        # The receiving face's reflectance is applied exactly once, where the flux is absorbed
+        i = findfirst(>(0), state3.flux_rad)
+        @test AsteroidThermoPhysicalModels.absorbed_energy_flux(0.1, 0.3, 0.0, 0.0, state3.flux_rad[i]) ≈ 0.7 * state3.flux_rad[i]
+    end
+
+    @testset "mutual heating flux_rad is independent of R_ir" begin
+        # Two flat faces facing each other: the secondary sits above the primary, flipped so
+        # that its normal points down. Mutual heating must not depend on either R_ir.
+        grid_params = GridParams(; z_max=0.1, n_depth=10)
+        path_obj = joinpath(@__DIR__, "shape", "single_face.obj")
+        make_binary(R_ir) = begin
+            thermo_params = ThermoParams(conductivity=0.1, density=1000.0, heat_capacity=700.0,
+                                         reflectance_vis=0.1, reflectance_ir=R_ir, emissivity=0.9)
+            shape1 = load_shape_obj(path_obj)
+            shape2 = load_shape_obj(path_obj)
+            problem = BinaryAsteroidThermoPhysicalProblem((shape1, shape2), thermo_params, grid_params;
+                with_self_shadowing=false, with_self_heating=false,
+                with_mutual_shadowing=false, with_mutual_heating=true)
+            state = AsteroidThermoPhysicalModels._build_binary_state(problem, CrankNicolson())
+            AsteroidThermoPhysicalModels.init_temperature!(state, 250.0, 300.0)
+            r₁₂ = SVector(0.0, 0.0, 1.0)                       # secondary 1 m above the primary
+            R₂₁ = SMatrix{3,3}(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, -1.0)   # flipped
+            AsteroidThermoPhysicalModels.mutual_heating!(state, r₁₂, R₂₁)
+            state
+        end
+        state0 = make_binary(0.0)
+        state3 = make_binary(0.3)
+
+        @test all(>(0), state0.primary.flux_rad)
+        @test all(>(0), state0.secondary.flux_rad)
+        @test state3.primary.flux_rad   == state0.primary.flux_rad
+        @test state3.secondary.flux_rad == state0.secondary.flux_rad
+    end
 end


### PR DESCRIPTION
## Summary

`flux_rad` carried the thermal-infrared reflectance of the **emitting** face. Found while reviewing #229.

```julia
state.flux_rad[i] += ε * σ_SB * (1 - R_ir) * fᵢⱼ * Tⱼ^4     # R_ir = reflectance_ir[j]
```

Everything else in the code base treats `flux_rad` as an *incident* flux, like `flux_sun` and `flux_scat`:

| Where | Expression | Treats `flux_rad` as |
|---|---|---|
| surface boundary condition / `absorbed_energy_flux` | `(1 − R_vis)(F_sun + F_scat) + (1 − R_ir) F_rad` | incident, absorbed with the *receiver's* reflectance |
| `update_thermal_force!` | `Eᵢ = R_vis F_sun + R_vis F_scat + R_ir F_rad + ε σ T⁴` | incident, reflected with the *receiver's* reflectance |
| `flux_scat` | `fᵢⱼ × R_vis[j] × flux_sun[j]` | incident (`R_vis[j]` is what the source reflects, not an absorptivity) |

So the factor was applied twice — once at the source, once at the receiver — and the absorbed thermal radiation came out short by `1 − R_ir` whenever `R_ir ≠ 0`. It has no counterpart on the scattered-light side.

The factor dates from the 2021 code, where `A_TH` was one scalar for the whole body and the source/receiver distinction did not exist (`flux.rad *= ε σ (1 − A_TH)` followed by `sum_incidence` applying `(1 − A_TH)` again). The per-face refactor (#143) fixed the index on the source.

This PR drops the factor in both the single-asteroid term and the binary `mutual_heating!`, and states the convention in the docstrings. Nothing changes for the default `R_ir = 0`, which every existing test uses; recorded under *Fixed* in the CHANGELOG.

The view factor itself is used correctly: the graph stores `Fᵢⱼ = cosθᵢ cosθⱼ Aⱼ / (π d²)` in row `i`, and the irradiance on `i` from `j` is `Eⱼ Aⱼ Fⱼᵢ / Aᵢ = Eⱼ Fᵢⱼ` by reciprocity.

## Test plan

New testsets in `test/thermal_radiation.jl`:

- [x] Self-heating on a concave crater gives the same `flux_rad` for `R_ir = 0` and `R_ir = 0.3`, matches the explicit `Σⱼ εⱼ σ Tⱼ⁴ Fᵢⱼ` face by face (with a temperature gradient so a wrong face index would show), and `absorbed_energy_flux` applies the receiver's `1 − R_ir` exactly once.
- [x] Mutual heating between two facing faces gives the same `flux_rad` on both bodies for `R_ir = 0` and `R_ir = 0.3`.
- [x] All existing tests pass unchanged (Ryugu, Didymos and the hierarchical tests all use `R_ir = 0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
