### PR TITLE
feat: advance the sub-face temperatures of each roughness model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,8 +100,10 @@ grid_params.Δz
   each roughness model and add the flux the parent face receives from the other global faces,
   distributed over the sub-faces by their sky view factor. Self-shadowing and self-heating
   inside a roughness model are always on; the problem's `with_self_heating` governs the global
-  faces and, through them, the external irradiation of the sub-faces. Sub-face temperature
-  updates land in a later release of the v0.3.0 series
+  faces and, through them, the external irradiation of the sub-faces. `update_temperature!`
+  advances the sub-faces after the global faces, each as a full set of 1D columns driven by its
+  own fluxes. Sub-face thermal forces and the `solve` integration land in a later release of
+  the v0.3.0 series
 
 ### Changed
 

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -61,13 +61,14 @@ function update_temperature_zero_conductivity!(state::SingleLevelThermoPhysicalS
 end
 
 """
-    update_temperature!(state::SingleLevelThermoPhysicalState, Δt)
+    update_temperature!(state::SingleAsteroidThermoPhysicalState, Δt)
+    update_temperature!(state::HierarchicalSingleAsteroidThermoPhysicalState, Δt)
 
 Update the temperature distribution for the next time step by solving the 1D heat conduction equation.
 The solver method is determined by `state.solver_cache`, and special handling is applied for zero conductivity.
 
 # Arguments
-- `state::SingleLevelThermoPhysicalState` : Thermophysical simulation state for a single asteroid
+- `state` : Thermophysical simulation state for a single asteroid, with or without surface roughness
 - `Δt::Real` : Time step [s]
 
 # Solver Selection
@@ -81,10 +82,11 @@ The function automatically selects the appropriate solver based on `state.solver
 - The zero-conductivity case uses instantaneous radiative equilibrium
 
 # Notes
-- For a `HierarchicalSingleAsteroidThermoPhysicalState`, only the global-level temperature
-  is advanced; the sub-face states in `roughness_states` are left untouched. The global
-  faces are solved independently of their roughness models and serve as the smooth-surface
-  baseline for the same run.
+- For a `HierarchicalSingleAsteroidThermoPhysicalState`, the global faces are advanced first
+  and then every sub-face state in `roughness_states`, each a full set of 1D columns driven by
+  its own fluxes and using its own solver cache. The global faces are solved independently of
+  their roughness models and serve as the smooth-surface baseline for the same run; nothing
+  flows from the sub-faces back to them.
 
 # Mathematical Background
 Solves the 1D heat conduction equation:
@@ -97,7 +99,17 @@ where α = k/(ρCₚ) is the thermal diffusivity.
 - `explicit_euler!`, `implicit_euler!`, `crank_nicolson!` for specific solver implementations
 - `update_temperature_zero_conductivity!` for the zero-conductivity case
 """
-function update_temperature!(state::SingleLevelThermoPhysicalState, Δt)
+update_temperature!(state::SingleAsteroidThermoPhysicalState, Δt) = _update_temperature!(state, Δt)
+
+function update_temperature!(state::HierarchicalSingleAsteroidThermoPhysicalState, Δt)
+    _update_temperature!(state, Δt)      # global faces: the smooth-surface baseline
+    for rs in state.roughness_states      # sub-faces of each roughness model
+        _update_temperature!(rs, Δt)
+    end
+end
+
+# Advance the faces that `state` describes directly, by the solver its cache was built for.
+function _update_temperature!(state::SingleLevelThermoPhysicalState, Δt)
     # Handle zero-conductivity case
     if iszero(state.problem.thermo_params.conductivity)
         update_temperature_zero_conductivity!(state)

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -13,6 +13,9 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
   the roughness model, the external irradiation from the other global faces, and its absence
   when the global self-heating is off
 - update_temperature! on the global level, for all three solvers and for zero conductivity
+- update_temperature! on the sub-face level: the sub-faces advance, a near-flat roughness model
+  reproduces the temperature of its parent face, and zero conductivity gives radiative
+  equilibrium on every sub-face
 =#
 
 @testset "HierarchicalSingleAsteroidThermoPhysicalState" begin
@@ -569,11 +572,55 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
             @test state_hier.temperature == state_plain.temperature
             @test state_hier.temperature != T₀
 
-            # Sub-face states are not advanced by the global-level update
+            # Sub-faces advance too (every face radiates, so none stays at its initial value)
             for (i, k) in enumerate(state_hier.face_roughness_indices)
                 k == 0 && continue
-                @test all(state_hier.roughness_states[k].temperature .== T₀[begin, i])
+                @test any(state_hier.roughness_states[k].temperature .!= T₀[begin, i])
             end
+        end
+    end
+
+    @testset "update_temperature! (sub-face level, near-flat reproduces the parent)" begin
+        # A roughness model flat to 1e-6 sees the same flux as its parent face and has the same
+        # material and grid, so after any number of steps every one of its columns must match
+        # the parent's column. This exercises the whole chain — local illumination, sub-face
+        # boundary condition, per-state solver cache — against the global-level result, which
+        # #226 pinned to the plain ShapeModel. The convex icosahedron keeps the external
+        # irradiation at zero, so nothing else enters.
+        path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
+        r☉ = SVector(0.3, -0.2, 0.9) * AsteroidThermoPhysicalModels.au2m
+        r̂☉ = normalize(r☉)
+        Δt = 100.0
+        n_steps = 10
+
+        for algorithm in (CrankNicolson(), ImplicitEuler(), ExplicitEuler())
+            shape_hier = load_shape_obj(path_obj; as_hierarchical=true)
+            add_roughness_models!(shape_hier, create_shape_crater(0.4, 1e-6; Nx=4, Ny=4))
+            problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+                with_self_shadowing=true, with_self_heating=false)
+            state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, algorithm)
+            AsteroidThermoPhysicalModels.init_temperature!(state_hier, 250.0)
+
+            for _ in 1:n_steps
+                AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+                AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
+                AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
+                AsteroidThermoPhysicalModels.update_temperature!(state_hier, Δt)
+            end
+            @test any(state_hier.temperature .!= 250.0)
+
+            n_checked = 0
+            for (i, k) in enumerate(state_hier.face_roughness_indices)
+                rs = state_hier.roughness_states[k]
+                # Skip grazing incidence, where the 1e-6 tilt of the sub-face normals is not
+                # small against cos θ of the parent (same reasoning as for the fluxes)
+                state_hier.illuminated_faces[i] && shape_hier.global_shape.face_normals[i] ⋅ r̂☉ < 0.05 && continue
+                n_checked += 1
+                for j in axes(rs.temperature, 2)
+                    @test all(isapprox.(rs.temperature[:, j], state_hier.temperature[:, i]; rtol=1e-5))
+                end
+            end
+            @test n_checked > 0
         end
     end
 
@@ -621,5 +668,15 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
             @test state_hier.temperature[begin, i] ≈ (F_abs / εσ)^(1/4)
         end
         @test any(>(0), state_hier.temperature[begin, :])
+
+        # The same holds on every sub-face, with the sub-face's own fluxes
+        for rs in state_hier.roughness_states
+            for j in axes(rs.temperature, 2)
+                F_abs = AsteroidThermoPhysicalModels.absorbed_energy_flux(
+                    0.1, 0.0, rs.flux_sun[j], rs.flux_scat[j], rs.flux_rad[j])
+                @test rs.temperature[begin, j] ≈ (F_abs / εσ)^(1/4)
+            end
+            @test any(>(0), rs.temperature[begin, :])
+        end
     end
 end


### PR DESCRIPTION
## Summary

Sub-face heat conduction. `update_temperature!` on a `HierarchicalSingleAsteroidThermoPhysicalState` now advances the global faces and then every sub-face state, each a full set of 1D columns driven by its own fluxes (#227, #229) and using its own solver cache (#222).

```julia
update_temperature!(state::SingleAsteroidThermoPhysicalState, Δt) = _update_temperature!(state, Δt)

function update_temperature!(state::HierarchicalSingleAsteroidThermoPhysicalState, Δt)
    _update_temperature!(state, Δt)      # global faces: the smooth-surface baseline
    for rs in state.roughness_states      # sub-faces of each roughness model
        _update_temperature!(rs, Δt)
    end
end
```

The body that picks the solver (#226 had already widened it to `SingleLevelThermoPhysicalState`) becomes `_update_temperature!`, shared by both levels. No solver code changes. The global faces are solved first and nothing flows from the sub-faces back to them: they remain the smooth-surface baseline.

With this, everything a hierarchical state needs per time step exists except the thermal force (next step) and the `solve` integration.

## Test plan

- [x] **Near-flat roughness reproduces the parent column.** A roughness model flat to 1e-6 sees the same flux as its parent face and has the same material and grid, so after ten steps every one of its columns must match the parent's, for Crank–Nicolson, implicit and explicit Euler. This exercises the whole chain — local illumination, sub-face boundary condition, per-state solver cache — against the global level, which #226 pinned to the plain `ShapeModel`. Grazing incidence is skipped, where the 1e-6 tilt of the sub-face normals is not small against cos θ (same reasoning as for the fluxes in #227).
- [x] **Zero conductivity** gives radiative equilibrium `εσT⁴ = F_abs` on every sub-face with its own fluxes.
- [x] The #226 assertion that sub-faces stay at their initial temperature becomes its opposite: every sub-face moves.
- [x] All existing tests pass unchanged; the global-level comparison against the plain `ShapeModel` from #226 still holds exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
