### PR TITLE
feat: thermal force of the roughness sub-faces, summed onto the parent face as a representative patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,14 @@ grid_params.Δz
   inside a roughness model are always on; the problem's `with_self_heating` governs the global
   faces and, through them, the external irradiation of the sub-faces. `update_temperature!`
   advances the sub-faces after the global faces, each as a full set of 1D columns driven by its
-  own fluxes. Sub-face thermal forces and the `solve` integration land in a later release of
-  the v0.3.0 series
+  own fluxes. `update_thermal_force!` computes the recoil on every sub-face, including the
+  momentum of photons re-absorbed inside the roughness model, and replaces the force on the
+  parent face by the sum, counted for the parent's area as a representative patch
+  (`F_i = (A_i / A_proj) Σⱼ fⱼ`, rotated into the body frame; the roughness `scale` cancels);
+  the torque acts at the parent face centre, and with `with_self_heating` the photons that
+  leave the roughness model towards the sky and are intercepted by other global faces are
+  accounted for isotropically. The `solve` integration lands in a later release of the v0.3.0
+  series
 
 ### Changed
 

--- a/docs/src/physical_model.md
+++ b/docs/src/physical_model.md
@@ -152,6 +152,19 @@ where ``\mathbf{F}_i`` is the recoil force on facet ``i`` (direct emission and r
 !!! warning "Net force before v0.3.0"
     Up to v0.2.1 the net force was accumulated as ``\sum_i (\hat{\mathbf{r}}_i \cdot \mathbf{F}_i)\,\hat{\mathbf{r}}_i`` — each facet force projected onto the direction of its centre from the origin. This has no physical basis and dropped the tangential part of every facet force; it was corrected in [#232](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl/pull/232). It is harmless on a sphere centred at the origin, where ``\hat{\mathbf{r}}_i = \hat{\mathbf{n}}_i``, and on symmetric polyhedra whose facet centres lie along their normals, but on an irregular body it biases the Yarkovsky force. As an order of magnitude, on the 49k-facet Ryugu shape the rotation-averaged net force came out about 7 % too small in magnitude and 6° off in direction. Net forces computed with earlier versions on non-spherical shapes should be recomputed.
 
+### Facets with a roughness model
+
+When a facet ``i`` of a `HierarchicalShapeModel` carries a roughness model, the recoil is computed on every sub-facet ``j`` of that model in its local frame — direct emission and reflection, plus the momentum of photons intercepted by the other sub-facets, which is always included — and the facet force is replaced by their sum. The roughness model is a patch that represents the surface of the facet statistically, so the sum is counted for the area of the facet rather than for the area of the patch:
+
+```math
+\mathbf{F}_i = \frac{A_i}{A_\mathrm{proj}} \, \mathbf{R}_i^{\mathsf T} \sum_j \mathbf{f}_j, \qquad
+A_\mathrm{proj} = \sum_j a_j \, (\hat{\mathbf{n}}_j \cdot \hat{\mathbf{z}})
+```
+
+where ``\mathbf{f}_j`` and ``a_j`` are the force and area of sub-facet ``j`` in the units of the roughness model, ``A_\mathrm{proj}`` is the area of the model projected onto its reference plane (``\hat{\mathbf{z}}`` is the local normal), and ``\mathbf{R}_i`` rotates from the body frame to the local frame of facet ``i``. The `scale` given to `add_roughness_models!` does not enter: the force on one patch grows as ``\mathrm{scale}^2`` and the number of patches covering the facet falls as ``\mathrm{scale}^{-2}``. The torque uses the facet centre ``\mathbf{r}_i`` as the point of action; the torque of the patch about its own centre is smaller by the ratio of the patch size to the body size and is neglected.
+
+When self-heating is enabled, the photons that leave the roughness model towards the sky and are intercepted by other facets ``k`` of the global shape are accounted for as for a smooth facet, taking the emission of the patch as isotropic: the power ``P_{\mathrm{sky},i} = (A_i / A_\mathrm{proj}) \sum_j E_j a_j f_{\mathrm{sky},j}`` that escapes the model, with ``f_{\mathrm{sky},j}`` the sky view factor of sub-facet ``j``, contributes ``(P_{\mathrm{sky},i} / c) \sum_k f_{ik} \hat{\mathbf{d}}_{ik}``.
+
 ## Binary Asteroid Systems
 
 For binary asteroid systems, `AsteroidThermoPhysicalModels.jl` provides comprehensive modeling of thermal interactions between the primary and secondary bodies.

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -450,10 +450,14 @@ function _add_external_irradiance!(flux_sub::AbstractVector, shape::ShapeModel, 
     iszero(flux_parent) && return
     graph = shape.face_visibility_graph
     for j in eachindex(shape.faces)
-        f_sky = max(0.0, 1 - sum(get_view_factors(graph, j)))
-        flux_sub[j] += f_sky * flux_parent
+        flux_sub[j] += _sky_view_factor(graph, j) * flux_parent
     end
 end
+
+
+# Sky view factor of face `j`: the part of its hemisphere not covered by the other faces of
+# the same shape, `1 − Σₖ fⱼₖ`. Clamped at zero against round-off in the view factors.
+_sky_view_factor(graph::FaceVisibilityGraph, j::Integer) = max(0.0, 1 - sum(get_view_factors(graph, j)))
 
 """
     update_flux_scat_single!(state::BinaryAsteroidThermoPhysicalState)

--- a/src/non_grav.jl
+++ b/src/non_grav.jl
@@ -130,6 +130,93 @@ end
 
 
 """
+    update_thermal_force!(state::HierarchicalSingleAsteroidThermoPhysicalState)
+
+Calculate the thermal recoil force and torque on an asteroid with surface roughness.
+
+# Arguments
+- `state::HierarchicalSingleAsteroidThermoPhysicalState` : Thermophysical simulation state for a single asteroid with surface roughness
+
+# Algorithm
+1. Global level: the recoil on every global face from the smooth-surface fluxes and
+   temperatures, exactly as for `SingleAsteroidThermoPhysicalState`. This is the baseline, and
+   it is what a global face without a roughness model keeps.
+2. Sub-face level, for every global face `i` that carries a roughness model: the recoil on each
+   sub-face `j` in the local frame of the model, including the momentum of the photons
+   intercepted by the other sub-faces (self-heating inside a roughness model is always on).
+   The roughness model is a patch that represents the surface of the parent face
+   statistically, so the sum is counted for the parent's area rather than for the area of
+   the patch, and rotated into the body frame:
+   ```
+   F_i = (A_i / A_proj) × R_iᵀ Σⱼ f_j,    A_proj = Σⱼ a_j (n̂_j ⋅ ẑ)
+   ```
+   where `f_j` and `a_j` are the force and area of sub-face `j` in the units of the model,
+   `A_proj` is the area of the model projected onto its reference plane, and `R_i` rotates
+   from the body frame to the local frame. The `scale` of the roughness model cancels: the
+   force on one patch grows as `scale²` and the number of patches covering the face falls as
+   `scale⁻²`. The result replaces `face_forces[i]`.
+3. With `with_self_heating`, the photons that leave the roughness model towards the sky and
+   are intercepted by other global faces `k` are accounted for as for a smooth face, taking
+   the emission of the patch as isotropic: the power escaping the model,
+   `P_sky = (A_i / A_proj) Σⱼ E_j a_j f_sky,j`, contributes `P_sky / c × Σₖ f_ik d̂_ik`.
+   This is the momentum counterpart of the external irradiation of the sub-faces.
+4. `force` and `torque` are summed from the resulting `face_forces`. The torque takes the
+   centre of the parent face as the point of action; the torque of the patch about its own
+   centre is smaller by the ratio of the patch size to the body size and is neglected.
+
+# Notes
+- The sub-face states' own `force` and `torque` are summed about the local origin of each
+  roughness model and are not used here.
+- Only the derived quantities of the global faces are overwritten; their fluxes and
+  temperatures remain the smooth-surface solution.
+"""
+function update_thermal_force!(state::HierarchicalSingleAsteroidThermoPhysicalState)
+    shape             = state.problem.shape
+    global_shape      = shape.global_shape
+    with_self_heating = state.problem.with_self_heating
+
+    _update_face_forces!(state, global_shape)  # smooth-surface baseline on every global face
+
+    for (i, k) in enumerate(state.face_roughness_indices)
+        k == 0 && continue
+        rs = state.roughness_states[k]
+        roughness_shape = rs.problem.shape
+        update_thermal_force!(rs)  # includes the re-absorption inside the roughness model
+
+        # Representative patch: count the model-unit forces for the parent's area. The
+        # rotation is linear, so the sub-face forces are summed first and rotated once.
+        patches_per_face = global_shape.face_areas[i] / _projected_area(roughness_shape)
+        f_sum = sum(rs.face_forces)
+        state.face_forces[i] = patches_per_face * transform_physical_vector_local_to_global(shape, i, f_sum)
+
+        # Photons that leave the roughness model towards the sky and are intercepted by other
+        # global faces: the momentum counterpart of the external irradiation, isotropic.
+        if with_self_heating
+            graph_sub = roughness_shape.face_visibility_graph
+            P_sky = patches_per_face * sum(eachindex(roughness_shape.faces)) do j
+                _emittance(rs, j) * roughness_shape.face_areas[j] * _sky_view_factor(graph_sub, j)
+            end
+            view_factors = get_view_factors(global_shape.face_visibility_graph, i)
+            directions   = get_visible_face_directions(global_shape.face_visibility_graph, i)
+            for (fᵢₖ, d̂ᵢₖ) in zip(view_factors, directions)
+                state.face_forces[i] += P_sky / c₀ * fᵢₖ * d̂ᵢₖ
+            end
+        end
+    end
+
+    _accumulate_force_torque!(state, global_shape)
+end
+
+
+# Area of `shape` projected onto its reference plane, Σⱼ aⱼ (n̂ⱼ ⋅ ẑ), with ẑ the normal of the
+# reference plane in the local frame of a roughness model.
+function _projected_area(shape::ShapeModel)
+    ẑ = SVector(0.0, 0.0, 1.0)
+    sum(a * (n̂ ⋅ ẑ) for (a, n̂) in zip(shape.face_areas, shape.face_normals))
+end
+
+
+"""
     update_thermal_force!(state::BinaryAsteroidThermoPhysicalState)
 
 Calculate the thermal force and torque on every face and integrate them over all faces.

--- a/src/non_grav.jl
+++ b/src/non_grav.jl
@@ -12,6 +12,68 @@ These effects arise from the recoil momentum of photons emitted from the surface
 # ║                     Photon recoil force / torque                  ║
 # ╚═══════════════════════════════════════════════════════════════════╝
 
+# Total emittance of face `i`, Eᵢ [W/m²]: reflected sunlight and scattered light, reflected
+# thermal radiation, and thermal emission. Both reflection and emission are taken as isotropic.
+function _emittance(state::SingleLevelThermoPhysicalState, i::Integer)
+    R_vis = state.problem.thermo_params.reflectance_vis[i]
+    R_ir  = state.problem.thermo_params.reflectance_ir[i]
+    ε     = state.problem.thermo_params.emissivity[i]
+    Tᵢ    = state.temperature[begin, i]
+
+    R_vis * state.flux_sun[i] + R_vis * state.flux_scat[i] + R_ir * state.flux_rad[i] + ε * σ_SB * Tᵢ^4
+end
+
+
+# Recoil force on every face of `shape`, written to `state.face_forces`. The net force and
+# torque are left to `_accumulate_force_torque!`, so that a caller may adjust individual face
+# forces in between. The shape is passed explicitly, as for the flux updates, so the caller
+# decides which level of a `HierarchicalShapeModel` is being updated.
+function _update_face_forces!(state::SingleLevelThermoPhysicalState, shape::ShapeModel)
+    with_self_heating = state.problem.with_self_heating
+    with_self_heating && _require_face_visibility_graph(shape, "with_self_heating")
+
+    for i in eachindex(shape.faces)
+        n̂ᵢ = shape.face_normals[i]
+        aᵢ = shape.face_areas[i]
+        Eᵢ = _emittance(state, i)
+
+        ## Thermal force on each face
+        # Photon recoil force: F = -momentum flux = -Energy flux / c
+        # The factor 2/3 comes from Lambertian emission (isotropic in hemisphere)
+        # For Lambertian surface: ∫cos(θ)dΩ = 2π/3 over hemisphere
+        state.face_forces[i] = - 2/3 * Eᵢ * aᵢ / c₀ * n̂ᵢ  # Direct recoil force normal to face
+
+        if with_self_heating
+            # Face properties visible from `i`: View factors and directions
+            view_factors = get_view_factors(shape.face_visibility_graph, i)
+            directions = get_visible_face_directions(shape.face_visibility_graph, i)
+
+            for (fᵢⱼ, d̂ᵢⱼ) in zip(view_factors, directions)
+                # Self-heating contribution: photons re-absorbed by other faces
+                # No 2/3 factor here because the direction is already specified by d̂ᵢⱼ
+                state.face_forces[i] += Eᵢ * aᵢ / c₀ * fᵢⱼ * d̂ᵢⱼ  # Re-absorption recoil force
+            end
+        end
+    end
+end
+
+
+# Net force and torque from `state.face_forces`. The net force is the plain sum of the face
+# forces: where a force acts does not enter the motion of the centre of mass, only the torque.
+# The torque is taken about the body-fixed origin, which is assumed to be the centre of mass.
+function _accumulate_force_torque!(state::SingleLevelThermoPhysicalState, shape::ShapeModel)
+    state.force  .= 0.
+    state.torque .= 0.
+
+    for i in eachindex(shape.faces)
+        rᵢ  = shape.face_centers[i]
+        dfᵢ = state.face_forces[i]
+        state.force  .+= dfᵢ        # Thermal force
+        state.torque .+= rᵢ × dfᵢ   # Thermal torque
+    end
+end
+
+
 """
     update_thermal_force!(state::SingleAsteroidThermoPhysicalState)
 
@@ -61,55 +123,9 @@ enabled; without it, every emitted photon counts as having left the body.
 - Rozitis, B., & Green, S. F. (2012). The influence of rough surface thermal-infrared beaming
 """
 function update_thermal_force!(state::SingleAsteroidThermoPhysicalState)
-    state.force  .= 0.
-    state.torque .= 0.
-
-    with_self_heating = state.problem.with_self_heating
-    with_self_heating && _require_face_visibility_graph(state.problem.shape, "with_self_heating")
-
-    for i in eachindex(state.problem.shape.faces)
-        rᵢ = state.problem.shape.face_centers[i]
-        n̂ᵢ = state.problem.shape.face_normals[i]
-        aᵢ = state.problem.shape.face_areas[i]
-
-        F_sun  = state.flux_sun[i]
-        F_scat = state.flux_scat[i]
-        F_rad  = state.flux_rad[i]
-        Tᵢ = state.temperature[begin, i]
-
-        ## Total emittance from face i , Eᵢ [W/m²].
-        ## Note that both scattered light and thermal radiation are assumed to be isotropic.
-        R_vis = state.problem.thermo_params.reflectance_vis[i]
-        R_ir  = state.problem.thermo_params.reflectance_ir[i]
-        ε     = state.problem.thermo_params.emissivity[i]
-        Eᵢ    = R_vis * F_sun + R_vis * F_scat + R_ir * F_rad + ε * σ_SB * Tᵢ^4
-
-        ## Thermal force on each face
-        # Photon recoil force: F = -momentum flux = -Energy flux / c
-        # The factor 2/3 comes from Lambertian emission (isotropic in hemisphere)
-        # For Lambertian surface: ∫cos(θ)dΩ = 2π/3 over hemisphere
-        state.face_forces[i] = - 2/3 * Eᵢ * aᵢ / c₀ * n̂ᵢ  # Direct recoil force normal to face
-        
-        if with_self_heating
-            # Face properties visible from `i`: View factors and directions
-            view_factors = get_view_factors(state.problem.shape.face_visibility_graph, i)
-            directions = get_visible_face_directions(state.problem.shape.face_visibility_graph, i)
-            
-            for (fᵢⱼ, d̂ᵢⱼ) in zip(view_factors, directions)
-                # Self-heating contribution: photons re-absorbed by other faces
-                # No 2/3 factor here because the direction is already specified by d̂ᵢⱼ
-                state.face_forces[i] += Eᵢ * aᵢ / c₀ * fᵢⱼ * d̂ᵢⱼ  # Re-absorption recoil force
-            end
-        end
-
-        ## Thermal force and torque on the entire shape. The net force is the plain sum of
-        ## the face forces: where a force acts does not enter the motion of the centre of
-        ## mass, only the torque. The torque is taken about the body-fixed origin, which is
-        ## assumed to be the centre of mass.
-        dfᵢ = state.face_forces[i]
-        state.force  .+= dfᵢ        # Thermal force
-        state.torque .+= rᵢ × dfᵢ   # Thermal torque
-    end
+    shape = state.problem.shape
+    _update_face_forces!(state, shape)
+    _accumulate_force_torque!(state, shape)
 end
 
 

--- a/test/test_hierarchical_state.jl
+++ b/test/test_hierarchical_state.jl
@@ -16,6 +16,10 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
 - update_temperature! on the sub-face level: the sub-faces advance, a near-flat roughness model
   reproduces the temperature of its parent face, and zero conductivity gives radiative
   equilibrium on every sub-face
+- update_thermal_force!: faces without roughness keep the plain result, a near-flat roughness
+  model reproduces the force on its parent face, the roughness scale cancels, a deep crater
+  changes the force and the net force/torque are re-summed, and the sky re-absorption term
+  follows the global self-heating flag
 =#
 
 @testset "HierarchicalSingleAsteroidThermoPhysicalState" begin
@@ -677,6 +681,182 @@ Unit tests for HierarchicalSingleAsteroidThermoPhysicalState:
                 @test rs.temperature[begin, j] ≈ (F_abs / εσ)^(1/4)
             end
             @test any(>(0), rs.temperature[begin, :])
+        end
+    end
+
+    # ---- update_thermal_force! ----------------------------------------------------------
+
+    # One flux update followed by the thermal force, on a state whose temperature is set.
+    function update_fluxes_and_force!(state, r☉)
+        AsteroidThermoPhysicalModels.update_flux_sun!(state, r☉)
+        AsteroidThermoPhysicalModels.update_flux_scat_single!(state)
+        AsteroidThermoPhysicalModels.update_flux_rad_single!(state)
+        AsteroidThermoPhysicalModels.update_thermal_force!(state)
+    end
+
+    @testset "update_thermal_force! (global level, partial roughness)" begin
+        # A global face without a roughness model keeps the plain ShapeModel force exactly;
+        # the one face with a crater gets a different force (its recoil is that of the crater).
+        path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
+        shape_plain = load_shape_obj(path_obj)
+        shape_hier  = load_shape_obj(path_obj; as_hierarchical=true)
+        add_roughness_models!(shape_hier, roughness_model, 1)
+
+        problem_plain = SingleAsteroidThermoPhysicalProblem(shape_plain, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        problem_hier  = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        state_plain = AsteroidThermoPhysicalModels._build_single_state(problem_plain, CrankNicolson())
+        state_hier  = AsteroidThermoPhysicalModels._build_single_state(problem_hier,  CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_plain, 250.0)
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier,  250.0)
+
+        r☉ = SVector(0.3, -0.2, 0.9) * AsteroidThermoPhysicalModels.au2m
+        update_fluxes_and_force!(state_plain, r☉)
+        update_fluxes_and_force!(state_hier,  r☉)
+
+        @test state_hier.face_forces[2:end] == state_plain.face_forces[2:end]
+        @test state_hier.face_forces[1]     != state_plain.face_forces[1]
+        @test state_hier.force ≈ sum(state_hier.face_forces)
+    end
+
+    @testset "update_thermal_force! (near-flat roughness reproduces the parent face)" begin
+        # A roughness model flat to 1e-6 has no self-heating and the normal of its parent, so
+        # the sum of its sub-face forces, counted for the parent's area and rotated back, must
+        # be the plain force on the parent. This pins both the rotation and the A_i / A_proj
+        # normalisation.
+        path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
+        shape_plain = load_shape_obj(path_obj)
+        shape_hier  = load_shape_obj(path_obj; as_hierarchical=true)
+        add_roughness_models!(shape_hier, create_shape_crater(0.4, 1e-6; Nx=4, Ny=4))
+
+        problem_plain = SingleAsteroidThermoPhysicalProblem(shape_plain, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        problem_hier  = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        state_plain = AsteroidThermoPhysicalModels._build_single_state(problem_plain, CrankNicolson())
+        state_hier  = AsteroidThermoPhysicalModels._build_single_state(problem_hier,  CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_plain, 250.0)
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier,  250.0)
+
+        r☉ = SVector(0.3, -0.2, 0.9) * AsteroidThermoPhysicalModels.au2m
+        r̂☉ = normalize(r☉)
+        update_fluxes_and_force!(state_plain, r☉)
+        update_fluxes_and_force!(state_hier,  r☉)
+
+        n_checked = 0
+        for i in eachindex(shape_plain.faces)
+            # Skip grazing incidence, where the 1e-6 tilt of the sub-face normals is not small
+            # against cos θ of the parent (same reasoning as for the fluxes)
+            state_hier.illuminated_faces[i] && shape_plain.face_normals[i] ⋅ r̂☉ < 0.05 && continue
+            n_checked += 1
+            @test isapprox(state_hier.face_forces[i], state_plain.face_forces[i]; rtol=1e-4)
+        end
+        @test n_checked > 0
+        @test isapprox(state_hier.force, state_plain.force; rtol=1e-4)
+    end
+
+    @testset "update_thermal_force! (roughness scale cancels)" begin
+        # The force on one patch grows as scale², the number of patches covering the face falls
+        # as scale⁻²: the face force must not depend on the scale of the roughness model.
+        path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
+        r☉ = SVector(0.3, -0.2, 0.9) * AsteroidThermoPhysicalModels.au2m
+
+        states = map((1.0, 0.1)) do scale
+            shape_hier = load_shape_obj(path_obj; as_hierarchical=true)
+            add_roughness_models!(shape_hier, roughness_model; scale)
+            problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+                with_self_shadowing=false, with_self_heating=false)
+            state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+            AsteroidThermoPhysicalModels.init_temperature!(state_hier, 250.0)
+            update_fluxes_and_force!(state_hier, r☉)
+            state_hier
+        end
+
+        @test all(isapprox.(states[1].face_forces, states[2].face_forces; rtol=1e-12))
+        @test isapprox(states[1].force,  states[2].force;  rtol=1e-12)
+        @test isapprox(states[1].torque, states[2].torque; rtol=1e-12)
+        @test any(f -> norm(f) > 0, states[1].face_forces)
+    end
+
+    @testset "update_thermal_force! (deep crater changes the force; net force and torque re-summed)" begin
+        path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
+        shape_plain = load_shape_obj(path_obj)
+        shape_hier  = load_shape_obj(path_obj; as_hierarchical=true)
+        add_roughness_models!(shape_hier, roughness_model)
+
+        problem_plain = SingleAsteroidThermoPhysicalProblem(shape_plain, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        problem_hier  = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false)
+        state_plain = AsteroidThermoPhysicalModels._build_single_state(problem_plain, CrankNicolson())
+        state_hier  = AsteroidThermoPhysicalModels._build_single_state(problem_hier,  CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_plain, 250.0)
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier,  250.0)
+
+        # A few steps so that the crater walls develop a temperature contrast
+        r☉ = SVector(0.3, -0.2, 0.9) * AsteroidThermoPhysicalModels.au2m
+        for state in (state_plain, state_hier), _ in 1:5
+            AsteroidThermoPhysicalModels.update_flux_sun!(state, r☉)
+            AsteroidThermoPhysicalModels.update_flux_scat_single!(state)
+            AsteroidThermoPhysicalModels.update_flux_rad_single!(state)
+            AsteroidThermoPhysicalModels.update_temperature!(state, 100.0)
+        end
+        update_fluxes_and_force!(state_plain, r☉)
+        update_fluxes_and_force!(state_hier,  r☉)
+
+        @test all(state_hier.face_forces .!= state_plain.face_forces)
+        @test all(f -> all(isfinite, f), state_hier.face_forces)
+        @test state_hier.force  ≈ sum(state_hier.face_forces)
+        @test state_hier.torque ≈ sum(r × f for (r, f) in zip(shape_hier.global_shape.face_centers, state_hier.face_forces))
+    end
+
+    @testset "update_thermal_force! (sky re-absorption term follows the global self-heating)" begin
+        # On a globally concave shape, the photons that leave a roughness model towards the sky
+        # can hit other global faces. Their momentum is added only when the global self-heating
+        # is on; without it the face force is exactly the normalised sum of the sub-face forces.
+        ẑ  = SVector(0.0, 0.0, 1.0)
+        c₀ = AsteroidThermoPhysicalModels.c₀
+        σ  = AsteroidThermoPhysicalModels.σ_SB
+        R_vis, R_ir, ε = 0.1, 0.0, 0.9   # as in `thermo_params`
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+
+        for with_self_heating in (true, false)
+            shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8, as_hierarchical=true)
+            add_roughness_models!(shape_hier, create_shape_crater(0.4, 0.1; Nx=4, Ny=4))
+            problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+                with_self_shadowing=false, with_self_heating)
+            state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+            AsteroidThermoPhysicalModels.init_temperature!(state_hier, 250.0)
+            update_fluxes_and_force!(state_hier, r☉)
+
+            global_shape = shape_hier.global_shape
+            n_sky = 0
+            for (i, k) in enumerate(state_hier.face_roughness_indices)
+                rs = state_hier.roughness_states[k]
+                rshape = rs.problem.shape
+                A_proj = sum(a * (n̂ ⋅ ẑ) for (a, n̂) in zip(rshape.face_areas, rshape.face_normals))
+                patches_per_face = global_shape.face_areas[i] / A_proj
+                patch = patches_per_face * transform_physical_vector_local_to_global(shape_hier, i, sum(rs.face_forces))
+
+                if with_self_heating
+                    P_sky = patches_per_face * sum(eachindex(rshape.faces)) do j
+                        E_j   = R_vis * (rs.flux_sun[j] + rs.flux_scat[j]) + R_ir * rs.flux_rad[j] + ε * σ * rs.temperature[begin, j]^4
+                        f_sky = max(0.0, 1 - sum(get_view_factors(rshape.face_visibility_graph, j)))
+                        E_j * rshape.face_areas[j] * f_sky
+                    end
+                    sky = sum(zip(get_view_factors(global_shape.face_visibility_graph, i),
+                                  get_visible_face_directions(global_shape.face_visibility_graph, i));
+                              init=zero(SVector{3, Float64})) do (f, d̂)
+                        P_sky / c₀ * f * d̂
+                    end
+                    norm(sky) > 0 && (n_sky += 1)
+                    @test isapprox(state_hier.face_forces[i], patch + sky; rtol=1e-12)
+                else
+                    @test isapprox(state_hier.face_forces[i], patch; rtol=1e-12)
+                end
+            end
+            with_self_heating && @test n_sky > 0
         end
     end
 end


### PR DESCRIPTION
## Summary

Step 8 of surface roughness support (v0.3.0): `update_thermal_force!` for `HierarchicalSingleAsteroidThermoPhysicalState`. Follows #227, #229, #231.

### Refactor (no behaviour change)

- `update_thermal_force!(::SingleAsteroidThermoPhysicalState)` is split into `_update_face_forces!(state, shape)` and `_accumulate_force_torque!(state, shape)`, with the shape passed explicitly as for the flux updates, so that a caller can adjust individual face forces before the net force and torque are summed. The emittance of a face moves into `_emittance`, and the sky view factor used by the external irradiation into `_sky_view_factor`.

### Sub-face thermal force

- **Baseline**: every global face gets the smooth-surface recoil as before. A face without a roughness model keeps it.
- **Representative patch**: for a face `i` with a roughness model, the recoil is computed on every sub-face `j` in the local frame (including the re-absorption inside the model, which is always on), and the face force is replaced by the sum, counted for the parent's area rather than the patch's:
  ```
  F_i = (A_i / A_proj) R_iᵀ Σ_j f_j,    A_proj = Σ_j a_j (n̂_j ⋅ ẑ)
  ```
  The roughness `scale` cancels (force per patch ∝ scale², patches per face ∝ scale⁻²). The torque acts at the parent face centre; the torque of the patch about its own centre is O(patch / body) and is neglected. `rs.force` / `rs.torque` are not used.
- **Sky re-absorption**: with `with_self_heating`, the power that leaves the model towards the sky, `P_sky = (A_i / A_proj) Σ_j E_j a_j f_sky,j`, is taken as isotropic and the momentum of the part intercepted by other global faces, `P_sky / c Σ_k f_ik d̂_ik`, is added — the counterpart of the external irradiation of the sub-faces.
- `force` and `torque` are re-summed from the resulting `face_forces`.

Only the derived quantities of the global faces are overwritten; their fluxes and temperatures remain the smooth-surface solution. The `solve` integration (step 9) is not in this PR.

### Docs

- `docs/src/physical_model.md`: new subsection *Facets with a roughness model* after *Net force and torque*, with the formulas above.
- CHANGELOG entry extended.

## Test plan

New testsets in `test/test_hierarchical_state.jl`:

- [x] **partial roughness** — faces without a roughness model have the plain `ShapeModel` force bit for bit; the one cratered face differs; `force == Σ face_forces`
- [x] **near-flat roughness reproduces the parent** — a model flat to 1e-6 gives the plain force on every non-grazing face to `rtol = 1e-4`; pins the local→body rotation and the `A_i / A_proj` normalisation together
- [x] **scale cancels** — the same crater at `scale = 1.0` and `0.1` gives the same `face_forces`, `force`, `torque` to 1e-12
- [x] **deep crater** — every face force differs from the smooth one, all finite, and `force` / `torque` equal the sums over `face_forces`
- [x] **sky term follows the global self-heating** — on a globally concave shape with `with_self_heating = true` the face force equals the patch term plus the sky term recomputed from the state fields (1e-12) and the sky term is non-zero on some faces; with `false` it equals the patch term alone
- [x] Full `Pkg.test()` passes locally (Julia 1.12.6); `test_tpm_with_force.jl` covers the unchanged `SingleAsteroidThermoPhysicalState` path through the refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)