### PR TITLE
feat: record the surface temperature of the roughness models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,13 @@ grid_params.Δz
   Recording the sub-face temperatures and the direction-dependent brightness temperature of a
   rough face follow in the next releases of the v0.3.0 series
 
+- **Roughness surface temperatures can be recorded**: `SingleAsteroidOutputSpec` gains
+  `roughness_face_ids` and `save_roughness_surface_temperature`; the solution carries
+  `roughness_surface_temperature::Dict{Int, Matrix}` (global face → `(n_sub, n_output)`) and
+  `export_solution` writes `roughness_surface_temperature.csv` in long format (`time`,
+  `face_id`, `sub_face_id`, `temperature`). `surface_temperature` remains the smooth-surface
+  baseline of the global faces
+
 ### Changed
 
 - **Breaking**: `ThermoParams` no longer holds grid parameters (`z_max`, `Δz`, `n_depth`); pass a `GridParams` instance separately

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -322,3 +322,17 @@ solution = solve(problem, CrankNicolson(); ephem=ephem, output=output, initial_t
 The recorded `surface_temperature` and `subsurface_temperature` are those of the global facets, which are solved independently of their roughness models and serve as the smooth-surface baseline of the same run. `face_forces`, `forces` and `torques` include the roughness: on a facet with a roughness model the force is the sum over its sub-facets, counted for the area of the facet (see *Facets with a roughness model* in the physical model). `absorbed_power` and `emitted_power` count such facets from their sub-facets in the same way.
 
 The problem's `with_self_heating` governs the global facets and, through them, the irradiation the sub-facets receive from the rest of the body; self-shadowing and self-heating inside a roughness model are always on.
+
+To record the temperatures of the rough surface itself, list the facets whose roughness models to save:
+
+```julia
+output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
+    roughness_face_ids                 = [1, 7],
+    save_roughness_surface_temperature = true,
+)
+solution = solve(problem, CrankNicolson(); ephem=ephem, output=output, initial_temperature=200.0)
+
+solution.roughness_surface_temperature[7]   # (n_sub, n_output): sub-facet j of the crater on facet 7, at each output time
+```
+
+`export_solution` then also writes `roughness_surface_temperature.csv` in long format (`time`, `face_id`, `sub_face_id`, `temperature`), since roughness models may differ in size from facet to facet. These temperatures, together with the roughness model's geometry and an observer direction, are what the direction-dependent brightness temperature of a rough facet is computed from.

--- a/src/tpm_solution.jl
+++ b/src/tpm_solution.jl
@@ -23,9 +23,15 @@ Encapsulates which timesteps, face indices, and physical quantities to record.
 - `save_face_forces`            : Save per-face thermal forces at `output_times` (default: `false`)
 - `save_forces`                 : Save net thermal force at `output_times` (default: `false`)
 - `save_torques`                : Save net thermal torque at `output_times` (default: `false`)
+- `roughness_face_ids`          : Global face indices whose roughness-model surface temperatures to save (default: empty)
+- `save_roughness_surface_temperature` : Save the surface temperature of every sub-face of the roughness
+  models on `roughness_face_ids` at `output_times` (default: `false`); requires a `HierarchicalShapeModel`
 
 # Notes
 - `save_subsurface_temperature = true` requires a non-empty `subsurface_face_ids`.
+- `save_roughness_surface_temperature = true` requires a non-empty `roughness_face_ids`, a problem
+  built on a `HierarchicalShapeModel`, and a roughness model on every listed face; the last two are
+  checked when the solution is allocated at `solve` time.
 - `save_face_forces` stores per-face forces in the body-fixed frame; it works with both
   `SingleAsteroidEphemerides{Nothing}` and `SingleAsteroidEphemerides{<:AbstractVector}`.
 - `save_forces` and `save_torques` require ephemerides with `R_body_to_inertial`
@@ -40,6 +46,8 @@ output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
     save_face_forces            = false,
     save_forces                 = true,
     save_torques                = true,
+    roughness_face_ids          = [1, 7],
+    save_roughness_surface_temperature = true,
 )
 ```
 """
@@ -51,6 +59,8 @@ struct SingleAsteroidOutputSpec
     save_face_forces            ::Bool
     save_forces                 ::Bool
     save_torques                ::Bool
+    roughness_face_ids                 ::Vector{Int}
+    save_roughness_surface_temperature ::Bool
 
     function SingleAsteroidOutputSpec(
         output_times,
@@ -60,10 +70,17 @@ struct SingleAsteroidOutputSpec
         save_face_forces,
         save_forces,
         save_torques,
+        roughness_face_ids,
+        save_roughness_surface_temperature,
     )
         if save_subsurface_temperature && isempty(subsurface_face_ids)
             throw(ArgumentError(
                 "subsurface_face_ids must be non-empty when save_subsurface_temperature = true"
+            ))
+        end
+        if save_roughness_surface_temperature && isempty(roughness_face_ids)
+            throw(ArgumentError(
+                "roughness_face_ids must be non-empty when save_roughness_surface_temperature = true"
             ))
         end
         new(
@@ -74,9 +91,21 @@ struct SingleAsteroidOutputSpec
             save_face_forces,
             save_forces,
             save_torques,
+            roughness_face_ids,
+            save_roughness_surface_temperature,
         )
     end
 end
+
+# Positional form without the roughness fields (no roughness output)
+SingleAsteroidOutputSpec(
+    output_times, subsurface_face_ids,
+    save_surface_temperature, save_subsurface_temperature, save_face_forces, save_forces, save_torques,
+) = SingleAsteroidOutputSpec(
+    output_times, subsurface_face_ids,
+    save_surface_temperature, save_subsurface_temperature, save_face_forces, save_forces, save_torques,
+    Int[], false,
+)
 
 function SingleAsteroidOutputSpec(
     output_times        ::Vector{Float64},
@@ -86,6 +115,8 @@ function SingleAsteroidOutputSpec(
     save_face_forces            ::Bool = false,
     save_forces                 ::Bool = false,
     save_torques                ::Bool = false,
+    roughness_face_ids                 ::Vector{Int} = Int[],
+    save_roughness_surface_temperature ::Bool = false,
 )
     SingleAsteroidOutputSpec(
         output_times,
@@ -95,6 +126,8 @@ function SingleAsteroidOutputSpec(
         save_face_forces,
         save_forces,
         save_torques,
+        roughness_face_ids,
+        save_roughness_surface_temperature,
     )
 end
 
@@ -215,11 +248,17 @@ Solution data for a single asteroid thermophysical simulation.
 - `face_forces`            : Per-face thermal force in the body-fixed frame [N], size `(n_face, n_save)`, or `nothing`
 - `forces`                 : Net thermal force in the inertial frame [N], size `(n_save,)`, or `nothing`
 - `torques`                : Net thermal torque in the inertial frame [N⋅m], size `(n_save,)`, or `nothing`
+- `roughness_surface_temperature` : Surface temperature of the sub-faces of the roughness model, by
+  global face ID, each entry `(n_sub, n_save)` [K], or `nothing`. Sub-face `j` is face `j` of the
+  roughness model attached to that global face
 
 # Notes
 - `forces` and `torques` are non-`nothing` only when the ephemerides include
   `R_body_to_inertial` (i.e., `SingleAsteroidEphemerides{<:AbstractVector}`) and the
   corresponding flag in `output` is `true`.
+- `surface_temperature` and `subsurface_temperature` are those of the global faces, i.e. the
+  smooth-surface baseline of a hierarchical run; `roughness_surface_temperature` is where the
+  rough-surface temperatures live.
 """
 struct SingleAsteroidThermoPhysicalSolution
     times          ::Vector{Float64}
@@ -233,6 +272,7 @@ struct SingleAsteroidThermoPhysicalSolution
     face_forces            ::Union{Nothing, Matrix{SVector{3, Float64}}}
     forces                 ::Union{Nothing, Vector{SVector{3, Float64}}}
     torques                ::Union{Nothing, Vector{SVector{3, Float64}}}
+    roughness_surface_temperature ::Union{Nothing, Dict{Int, Matrix{Float64}}}
 end
 
 
@@ -274,13 +314,29 @@ function _build_single_solution(
     face_forces            = output.save_face_forces            ? zeros(SVector{3,Float64}, n_face, n_save) : nothing
     forces                 = output.save_forces  ? zeros(SVector{3,Float64}, n_save) : nothing
     torques                = output.save_torques ? zeros(SVector{3,Float64}, n_save) : nothing
+    roughness_surface_temperature = output.save_roughness_surface_temperature ?
+        Dict{Int,Matrix{Float64}}(i => zeros(_n_roughness_faces(state, i), n_save) for i in output.roughness_face_ids) : nothing
 
     SingleAsteroidThermoPhysicalSolution(
         times, absorbed_power, emitted_power,
         output,
         depth_nodes, surface_temperature, subsurface_temperature, face_forces,
         forces, torques,
+        roughness_surface_temperature,
     )
+end
+
+# Number of sub-faces of the roughness model on global face `i`; raises when the state has no
+# roughness models at all, or face `i` carries none, since there would be nothing to save.
+_n_roughness_faces(state::SingleAsteroidThermoPhysicalState, i::Integer) = throw(ArgumentError(
+    "save_roughness_surface_temperature requires a problem built on a HierarchicalShapeModel"
+))
+function _n_roughness_faces(state::HierarchicalSingleAsteroidThermoPhysicalState, i::Integer)
+    k = state.face_roughness_indices[i]
+    k == 0 && throw(ArgumentError(
+        "roughness_face_ids contains face $i, which has no roughness model"
+    ))
+    return size(state.roughness_states[k].temperature, 2)
 end
 
 """
@@ -350,6 +406,13 @@ function record_timestep!(
 
     if solution.output.save_face_forces
         solution.face_forces[:, i_save] .= state.face_forces
+    end
+
+    if solution.output.save_roughness_surface_temperature
+        for (i, T_rough) in solution.roughness_surface_temperature
+            rs = state.roughness_states[state.face_roughness_indices[i]]
+            T_rough[:, i_save] .= surface_temperature(rs)
+        end
     end
 end
 
@@ -474,6 +537,23 @@ function _export_subsurface_temperature(dirpath, solution::SingleAsteroidThermoP
     CSV.write(filepath, df)
 end
 
+# Long format — one row per (time, global face, sub-face) — because roughness models may differ
+# in size from face to face, which a wide table with one column per face could not hold.
+function _export_roughness_surface_temperature(dirpath, solution::SingleAsteroidThermoPhysicalSolution)
+    output_times = solution.output.output_times
+    time_col, face_col, sub_col, T_col = Float64[], Int[], Int[], Float64[]
+    for i in sort(collect(keys(solution.roughness_surface_temperature)))
+        T_rough = solution.roughness_surface_temperature[i]
+        n_sub = size(T_rough, 1)
+        for (i_save, t) in enumerate(output_times), j in 1:n_sub
+            push!(time_col, t); push!(face_col, i); push!(sub_col, j); push!(T_col, T_rough[j, i_save])
+        end
+    end
+    df = DataFrame(time = time_col, face_id = face_col, sub_face_id = sub_col, temperature = T_col)
+    filepath = joinpath(dirpath, "roughness_surface_temperature.csv")
+    CSV.write(filepath, df)
+end
+
 function _export_thermal_face_forces(dirpath, solution::SingleAsteroidThermoPhysicalSolution)
     output_times = solution.output.output_times
     n_face = size(solution.face_forces, 1)
@@ -522,6 +602,8 @@ Files written depend on the `output` specification:
 - `subsurface_temperature.csv` : when `output.save_subsurface_temperature = true`
 - `thermal_face_forces.csv`    : when `output.save_face_forces = true`
 - `thermal_net_forces.csv`     : when `output.save_forces = true` or `output.save_torques = true`
+- `roughness_surface_temperature.csv` : when `output.save_roughness_surface_temperature = true`;
+  long format with columns `time`, `face_id`, `sub_face_id`, `temperature`
 """
 function export_solution(dirpath, solution::SingleAsteroidThermoPhysicalSolution)
     mkpath(dirpath)
@@ -530,6 +612,7 @@ function export_solution(dirpath, solution::SingleAsteroidThermoPhysicalSolution
     solution.output.save_subsurface_temperature && _export_subsurface_temperature(dirpath, solution)
     solution.output.save_face_forces            && _export_thermal_face_forces(dirpath, solution)
     (solution.output.save_forces || solution.output.save_torques) && _export_thermal_net_forces(dirpath, solution)
+    solution.output.save_roughness_surface_temperature && _export_roughness_surface_temperature(dirpath, solution)
 end
 
 

--- a/test/test_hierarchical_solve.jl
+++ b/test/test_hierarchical_solve.jl
@@ -144,6 +144,66 @@ End-to-end tests of `solve` on a `HierarchicalShapeModel`:
         @test abs(ratio - 1) < 0.05
     end
 
+    @testset "roughness surface temperature is recorded and exported" begin
+        times, ephem = make_ephem(1; with_rotation=false)
+        output_times = times[end-3:end]
+        n_sub = length(roughness_model.faces)
+
+        # A crater on faces 1 and 7 only; record both
+        shape_hier = load_shape_obj(path_obj; as_hierarchical=true)
+        add_roughness_models!(shape_hier, roughness_model, 1)
+        add_roughness_models!(shape_hier, roughness_model, 7)
+        output = SingleAsteroidOutputSpec(output_times, Int[];
+            save_subsurface_temperature = false,
+            roughness_face_ids = [7, 1], save_roughness_surface_temperature = true)
+        sol = solve(make_problem(shape_hier), CrankNicolson();
+            ephem, output, initial_temperature=200.0, show_progress=false)
+
+        @test sol.roughness_surface_temperature isa Dict{Int, Matrix{Float64}}
+        @test sort(collect(keys(sol.roughness_surface_temperature))) == [1, 7]
+        for (i, T_rough) in sol.roughness_surface_temperature
+            @test size(T_rough) == (n_sub, length(output_times))
+            @test all(isfinite, T_rough) && all(>(0), T_rough)
+            # The crater is not isothermal: its sub-faces spread around the smooth face
+            @test maximum(T_rough[:, end]) - minimum(T_rough[:, end]) > 1.0
+        end
+
+        # Exported in long format: one row per (time, face, sub-face)
+        dir = mktempdir()
+        export_solution(dir, sol)
+        file = joinpath(dir, "roughness_surface_temperature.csv")
+        @test isfile(file)
+        df = CSV.read(file, DataFrame)
+        @test names(df) == ["time", "face_id", "sub_face_id", "temperature"]
+        @test nrow(df) == 2 * n_sub * length(output_times)
+        @test sort(unique(df.face_id)) == [1, 7]
+        @test df.temperature[df.face_id .== 7 .&& df.sub_face_id .== 3 .&& df.time .== output_times[end]][1] ==
+              sol.roughness_surface_temperature[7][3, end]
+
+        # A roughness model flat to 1e-6 reproduces the smooth face's surface temperature
+        shape_flat = load_shape_obj(path_obj; as_hierarchical=true)
+        add_roughness_models!(shape_flat, create_shape_crater(0.4, 1e-6; Nx=4, Ny=4))
+        output_flat = SingleAsteroidOutputSpec(output_times, Int[];
+            save_subsurface_temperature = false,
+            roughness_face_ids = collect(1:length(shape_flat.global_shape.faces)),
+            save_roughness_surface_temperature = true)
+        sol_flat = solve(make_problem(shape_flat), CrankNicolson();
+            ephem, output=output_flat, initial_temperature=200.0, show_progress=false)
+        for (i, T_rough) in sol_flat.roughness_surface_temperature
+            @test all(isapprox.(T_rough, sol_flat.surface_temperature[i:i, :]; rtol=1e-4))
+        end
+
+        # Requesting a face without a roughness model, or a plain ShapeModel, is an error
+        output_bad = SingleAsteroidOutputSpec(output_times, Int[];
+            save_subsurface_temperature = false,
+            roughness_face_ids = [2], save_roughness_surface_temperature = true)
+        @test_throws ArgumentError solve(make_problem(shape_hier), CrankNicolson();
+            ephem, output=output_bad, initial_temperature=200.0, show_progress=false)
+        shape_plain = load_shape_obj(path_obj)
+        @test_throws ArgumentError solve(make_problem(shape_plain), CrankNicolson();
+            ephem, output, initial_temperature=200.0, show_progress=false)
+    end
+
     @testset "export_solution and show_progress" begin
         times, ephem = make_ephem(1; with_rotation=true)
         output_times = times[end-5:end]

--- a/test/test_output_spec.jl
+++ b/test/test_output_spec.jl
@@ -40,6 +40,13 @@ introduced in v0.2.0:
         @test output.save_face_forces            == false
         @test output.save_forces                 == false
         @test output.save_torques                == false
+        @test output.roughness_face_ids          == Int[]
+        @test output.save_roughness_surface_temperature == false
+
+        output_rough = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
+            roughness_face_ids = [1, 7], save_roughness_surface_temperature = true)
+        @test output_rough.roughness_face_ids == [1, 7]
+        @test output_rough.save_roughness_surface_temperature == true
     end
 
     @testset "SingleAsteroidOutputSpec inner constructor validation" begin
@@ -47,6 +54,9 @@ introduced in v0.2.0:
         @test_throws ArgumentError SingleAsteroidOutputSpec(output_times, Int[], true, true, false, true, true)
         # save_subsurface_temperature=false with empty subsurface_face_ids → OK
         @test_nowarn SingleAsteroidOutputSpec(output_times, Int[], true, false, false, true, true)
+        # save_roughness_surface_temperature=true with empty roughness_face_ids → ArgumentError
+        @test_throws ArgumentError SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
+            save_roughness_surface_temperature = true)
     end
 
     @testset "BinaryAsteroidOutputSpec construction" begin


### PR DESCRIPTION
## Summary

Step 9b of surface roughness support: record the surface temperature of the roughness models. Follows #234 and precedes the direction-dependent brightness temperature of a rough face, which is computed from these temperatures.

- **`SingleAsteroidOutputSpec`** gains `roughness_face_ids::Vector{Int}` and `save_roughness_surface_temperature::Bool` (default off). Naming follows the code base's vocabulary — `roughness` — rather than `sub_face`, which reads too close to `subsurface`.
- **`SingleAsteroidThermoPhysicalSolution`** gains `roughness_surface_temperature::Union{Nothing, Dict{Int, Matrix{Float64}}}`, global face → `(n_sub, n_output)`, the same shape as `subsurface_temperature`. Sub-face `j` is face `j` of the roughness model on that global face. Filled in `record_timestep!` from `surface_temperature` of the sub-face state.
- **`export_solution`** writes `roughness_surface_temperature.csv` in **long format** (`time`, `face_id`, `sub_face_id`, `temperature`). A wide table with one column per face, as for `subsurface_temperature.csv`, would not hold roughness models that differ in size from face to face.
- **Validation** at solution allocation: a plain `ShapeModel`, or a listed face without a roughness model, raises an `ArgumentError` — there would be nothing to save.

`surface_temperature` / `surface_temperature.csv` remain the smooth-surface baseline of the global faces; the rough-surface temperatures live only here.

## Test plan

- [x] Defaults (`Int[]`, `false`), keyword construction, and the empty-`roughness_face_ids` check
- [x] Partial roughness (craters on faces 1 and 7): keys `[1, 7]`, shape `(n_sub, n_output)`, finite and positive, the crater is not isothermal (spread > 1 K); the CSV has `2 · n_sub · n_output` rows and round-trips a value
- [x] A roughness model flat to 1e-6 on every face reproduces the smooth face's `surface_temperature` to `rtol = 1e-4`
- [x] A listed face without a roughness model, and a plain `ShapeModel`, raise `ArgumentError`
- [x] Full `Pkg.test()` passes; the positional 7-argument constructor used by existing tests is kept as a method without the roughness fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)
