### PR TITLE
refactor!: select subsurface and roughness outputs by face ids only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,22 @@ grid_params.Δz
 
 ### Changed
 
+- **Breaking**: `SingleAsteroidOutputSpec` selects the face-specific outputs by face lists
+  alone. `subsurface_face_ids` moves from a positional argument to a keyword, and the
+  `save_subsurface_temperature` / `save_roughness_surface_temperature` flags are removed: a
+  non-empty `subsurface_face_ids` / `roughness_face_ids` saves the corresponding output, an
+  empty list (the default) does not. The positional constructors are gone, and the
+  `BinaryAsteroidOutputSpec` convenience constructor takes the two `output_times` positionally
+  with `subsurface_face_ids_primary` / `subsurface_face_ids_secondary` as keywords
+  ```julia
+  # v0.2.x / early v0.3.0
+  output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids; save_forces=true)
+  output = SingleAsteroidOutputSpec(output_times, Int[]; save_subsurface_temperature=false)
+
+  # v0.3.0
+  output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids, save_forces=true)
+  output = SingleAsteroidOutputSpec(output_times)
+  ```
 - **Requires AsteroidShapeModels.jl v0.6**: surface roughness is carried by `ShapeModel`
   itself (`shape.roughness`, built by `add_roughness_models!`) — the former
   `HierarchicalShapeModel` wrapper no longer exists. Load shapes with plain

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ result = run_TPM!(stpm, ephem, times_to_save, face_ID)
 # v0.2.0
 ephem   = SingleAsteroidEphemerides(times, r_sun)
 problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params; ...)
-output  = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
-    save_surface_temperature    = true,
-    save_subsurface_temperature = true,
+output  = SingleAsteroidOutputSpec(output_times;
+    save_surface_temperature = true,
+    subsurface_face_ids      = subsurface_face_ids,
     save_face_forces            = false,
     save_forces                 = false,  # true requires R_body_to_inertial in ephem
     save_torques                = false,
@@ -133,7 +133,7 @@ problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
 # --- Output specification ---
 output_times        = ephem.times[end-119:end]  # final rotation period
 subsurface_face_ids = [1, 2, 3]                 # faces for saving subsurface temperature profiles
-output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
 
 # --- Solve ---
 solution = solve(problem, CrankNicolson();

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -87,7 +87,7 @@ problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
 output_times        = collect(et_range)[end-n_step_in_cycle:end]  # Save the final rotation
 subsurface_face_ids = [1, 2, 3, 4, 10]                            # Face indices for subsurface output
 
-output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
 
 ##= Run TPM =##
 solution = solve(problem, ExplicitEuler();
@@ -203,8 +203,8 @@ output_times        = collect(et_range)[end-n_step_in_cycle:end]
 subsurface_face_ids = [1, 2, 3, 4, 10]
 
 output = BinaryAsteroidOutputSpec(
-    SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
-    SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
+    SingleAsteroidOutputSpec(output_times; subsurface_face_ids),
+    SingleAsteroidOutputSpec(output_times; subsurface_face_ids),
 )
 
 ##= Run TPM =##
@@ -264,9 +264,10 @@ ephem = SingleAsteroidEphemerides(et_range, r_sun, R_body_to_inertial)
 # ...define problem as above...
 
 # Enable force and torque output
-output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
-    save_forces  = true,
-    save_torques = true,
+output = SingleAsteroidOutputSpec(output_times;
+    subsurface_face_ids = subsurface_face_ids,
+    save_forces         = true,
+    save_torques        = true,
 )
 
 solution = solve(problem, ExplicitEuler();
@@ -286,7 +287,7 @@ If only per-face forces in the body-fixed frame are needed (without rotation mat
 
 ```julia
 ephem  = SingleAsteroidEphemerides(et_range, r_sun)  # no rotation matrix required
-output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids; save_face_forces=true)
+output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids, save_face_forces=true)
 
 solution = solve(problem, ExplicitEuler(); ephem=ephem, output=output, initial_temperature=200.0)
 
@@ -326,9 +327,9 @@ The problem's `with_self_heating` governs the global facets and, through them, t
 To record the temperatures of the rough surface itself, list the facets whose roughness models to save:
 
 ```julia
-output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
-    roughness_face_ids                 = [1, 7],
-    save_roughness_surface_temperature = true,
+output = SingleAsteroidOutputSpec(output_times;
+    subsurface_face_ids = subsurface_face_ids,
+    roughness_face_ids  = [1, 7],
 )
 solution = solve(problem, CrankNicolson(); ephem=ephem, output=output, initial_temperature=200.0)
 

--- a/docs/src/migration.md
+++ b/docs/src/migration.md
@@ -8,6 +8,28 @@ This page summarizes breaking changes between versions and how to update your co
 
 The API changes of v0.2.0 and v0.3.0 are listed in the [changelog](https://github.com/Astroshaper/AsteroidThermoPhysicalModels.jl/blob/main/CHANGELOG.md).
 
+### `SingleAsteroidOutputSpec`: face-specific outputs are selected by face lists
+
+`subsurface_face_ids` is now a keyword, and the `save_subsurface_temperature` /
+`save_roughness_surface_temperature` flags are gone: listing faces switches the output on, an
+empty list (the default) leaves it off. Only the surface temperature is saved by default.
+
+```julia
+# before
+output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+output = SingleAsteroidOutputSpec(output_times, Int[]; save_subsurface_temperature=false, save_forces=true)
+output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
+    roughness_face_ids=[1, 7], save_roughness_surface_temperature=true)
+
+# after
+output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
+output = SingleAsteroidOutputSpec(output_times; save_forces=true)
+output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids, roughness_face_ids=[1, 7])
+```
+
+The `BinaryAsteroidOutputSpec` convenience constructor changes in the same way:
+`BinaryAsteroidOutputSpec(output_times_primary, output_times_secondary; subsurface_face_ids_primary, subsurface_face_ids_secondary, ...)`.
+
 ### Requires AsteroidShapeModels.jl v0.6
 
 v0.3.0 raises the AsteroidShapeModels.jl compat to `"0.6"`. Surface roughness is carried by

--- a/src/directional_radiance.jl
+++ b/src/directional_radiance.jl
@@ -99,7 +99,7 @@ Thermal radiance of every global facet towards the observer direction `d̂` (bod
 at output time `solution.output.output_times[i_save]`.
 
 Facets whose roughness-model surface temperatures were recorded
-(`output.roughness_face_ids` with `save_roughness_surface_temperature = true`) radiate
+(`output.roughness_face_ids`) radiate
 anisotropically according to [`roughness_radiance`](@ref); every other facet radiates as a
 smooth Lambertian surface, ``\\varepsilon B(T_i)/\\pi``, from its recorded `surface_temperature`.
 A facet seen from behind gives `NaN`.

--- a/src/tpm_solution.jl
+++ b/src/tpm_solution.jl
@@ -13,25 +13,23 @@ Solution types and export functions for thermophysical simulations.
 
 Output specification for a single-asteroid thermophysical simulation.
 
-Encapsulates which timesteps, face indices, and physical quantities to record.
+Encapsulates which timesteps, face indices, and physical quantities to record. Quantities
+recorded for every face are switched on and off by a `save_*` flag; quantities recorded for
+selected faces only are switched on by listing those faces — an empty list means "not saved".
 
 # Fields
-- `output_times`                : Timesteps at which data are saved [s]; must be a subset of `ephem.times`
-- `subsurface_face_ids`         : Face indices for which to save subsurface temperature profiles
-- `save_surface_temperature`    : Save surface temperature at `output_times` (default: `true`)
-- `save_subsurface_temperature` : Save subsurface temperature profiles at `output_times` (default: `true`)
-- `save_face_forces`            : Save per-face thermal forces at `output_times` (default: `false`)
-- `save_forces`                 : Save net thermal force at `output_times` (default: `false`)
-- `save_torques`                : Save net thermal torque at `output_times` (default: `false`)
-- `roughness_face_ids`          : Global face indices whose roughness-model surface temperatures to save (default: empty)
-- `save_roughness_surface_temperature` : Save the surface temperature of every sub-face of the roughness
-  models on `roughness_face_ids` at `output_times` (default: `false`); requires a shape with surface roughness
+- `output_times`             : Timesteps at which data are saved [s]; must be a subset of `ephem.times`
+- `save_surface_temperature` : Save the surface temperature of every face at `output_times` (default: `true`)
+- `subsurface_face_ids`      : Faces whose subsurface temperature profiles to save at `output_times` (default: none)
+- `roughness_face_ids`       : Faces whose roughness-model surface temperatures (every sub-face) to save
+  at `output_times` (default: none); requires a shape with surface roughness
+- `save_face_forces`         : Save the thermal force on every face at `output_times` (default: `false`)
+- `save_forces`              : Save the net thermal force at `output_times` (default: `false`)
+- `save_torques`             : Save the net thermal torque at `output_times` (default: `false`)
 
 # Notes
-- `save_subsurface_temperature = true` requires a non-empty `subsurface_face_ids`.
-- `save_roughness_surface_temperature = true` requires a non-empty `roughness_face_ids`, a problem
-  built on a shape with surface roughness, and a roughness model on every listed face; the last two
-  are checked when the solution is allocated at `solve` time.
+- `roughness_face_ids` requires a problem built on a shape with surface roughness and a roughness
+  model on every listed face; both are checked when the solution is allocated at `solve` time.
 - `save_face_forces` stores per-face forces in the body-fixed frame; it works with both
   `SingleAsteroidEphemerides{Nothing}` and `SingleAsteroidEphemerides{<:AbstractVector}`.
 - `save_forces` and `save_torques` require ephemerides with `R_body_to_inertial`
@@ -40,94 +38,48 @@ Encapsulates which timesteps, face indices, and physical quantities to record.
 
 # Example
 ```julia
-output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
-    save_surface_temperature    = true,
-    save_subsurface_temperature = true,
-    save_face_forces            = false,
-    save_forces                 = true,
-    save_torques                = true,
-    roughness_face_ids          = [1, 7],
-    save_roughness_surface_temperature = true,
+output = SingleAsteroidOutputSpec(output_times;
+    save_surface_temperature = true,
+    subsurface_face_ids      = [1, 2, 3],
+    roughness_face_ids       = [1, 7],
+    save_face_forces         = false,
+    save_forces              = true,
+    save_torques             = true,
 )
 ```
 """
 struct SingleAsteroidOutputSpec
-    output_times                ::Vector{Float64}
-    subsurface_face_ids         ::Vector{Int}
-    save_surface_temperature    ::Bool
-    save_subsurface_temperature ::Bool
-    save_face_forces            ::Bool
-    save_forces                 ::Bool
-    save_torques                ::Bool
-    roughness_face_ids                 ::Vector{Int}
-    save_roughness_surface_temperature ::Bool
-
-    function SingleAsteroidOutputSpec(
-        output_times,
-        subsurface_face_ids,
-        save_surface_temperature,
-        save_subsurface_temperature,
-        save_face_forces,
-        save_forces,
-        save_torques,
-        roughness_face_ids,
-        save_roughness_surface_temperature,
-    )
-        if save_subsurface_temperature && isempty(subsurface_face_ids)
-            throw(ArgumentError(
-                "subsurface_face_ids must be non-empty when save_subsurface_temperature = true"
-            ))
-        end
-        if save_roughness_surface_temperature && isempty(roughness_face_ids)
-            throw(ArgumentError(
-                "roughness_face_ids must be non-empty when save_roughness_surface_temperature = true"
-            ))
-        end
-        new(
-            output_times,
-            subsurface_face_ids,
-            save_surface_temperature,
-            save_subsurface_temperature,
-            save_face_forces,
-            save_forces,
-            save_torques,
-            roughness_face_ids,
-            save_roughness_surface_temperature,
-        )
-    end
+    output_times             ::Vector{Float64}
+    save_surface_temperature ::Bool
+    subsurface_face_ids      ::Vector{Int}
+    roughness_face_ids       ::Vector{Int}
+    save_face_forces         ::Bool
+    save_forces              ::Bool
+    save_torques             ::Bool
 end
 
-# Positional form without the roughness fields (no roughness output)
-SingleAsteroidOutputSpec(
-    output_times, subsurface_face_ids,
-    save_surface_temperature, save_subsurface_temperature, save_face_forces, save_forces, save_torques,
-) = SingleAsteroidOutputSpec(
-    output_times, subsurface_face_ids,
-    save_surface_temperature, save_subsurface_temperature, save_face_forces, save_forces, save_torques,
-    Int[], false,
-)
+"""
+    SingleAsteroidOutputSpec(output_times; kwargs...)
 
+Keyword constructor; see [`SingleAsteroidOutputSpec`](@ref) for the meaning of each keyword.
+"""
 function SingleAsteroidOutputSpec(
-    output_times        ::Vector{Float64},
-    subsurface_face_ids ::Vector{Int};
-    save_surface_temperature    ::Bool = true,
-    save_subsurface_temperature ::Bool = true,
-    save_face_forces            ::Bool = false,
-    save_forces                 ::Bool = false,
-    save_torques                ::Bool = false,
-    roughness_face_ids                 ::Vector{Int} = Int[],
-    save_roughness_surface_temperature ::Bool = false,
+    output_times             ::AbstractVector{<:Real};
+    save_surface_temperature ::Bool = true,
+    subsurface_face_ids      ::AbstractVector{<:Integer} = Int[],
+    roughness_face_ids       ::AbstractVector{<:Integer} = Int[],
+    save_face_forces         ::Bool = false,
+    save_forces              ::Bool = false,
+    save_torques             ::Bool = false,
 )
     SingleAsteroidOutputSpec(
-        output_times,
-        subsurface_face_ids,
+        convert(Vector{Float64}, output_times),
         save_surface_temperature,
-        save_subsurface_temperature,
+        convert(Vector{Int}, subsurface_face_ids),
+        convert(Vector{Int}, roughness_face_ids),
         save_face_forces,
         save_forces,
         save_torques,
-        roughness_face_ids,
-        save_roughness_surface_temperature,
     )
 end
 
@@ -144,19 +96,18 @@ Wraps two `SingleAsteroidOutputSpec` instances, one for each body.
 # Example
 ```julia
 # Convenience constructor: shared Bool flags, separate output_times and subsurface_face_ids
-output = BinaryAsteroidOutputSpec(
-    output_times_primary,   subsurface_face_ids_primary,
-    output_times_secondary, subsurface_face_ids_secondary;
-    save_surface_temperature    = true,
-    save_subsurface_temperature = true,
-    save_face_forces            = false,
-    save_forces                 = true,
-    save_torques                = true,
+output = BinaryAsteroidOutputSpec(output_times_primary, output_times_secondary;
+    subsurface_face_ids_primary   = [1, 2],
+    subsurface_face_ids_secondary = [3],
+    save_surface_temperature = true,
+    save_face_forces         = false,
+    save_forces              = true,
+    save_torques             = true,
 )
 
 # Base constructor: independent spec per body
-output_primary   = SingleAsteroidOutputSpec(output_times_primary,   subsurface_face_ids_primary;   save_forces=true)
-output_secondary = SingleAsteroidOutputSpec(output_times_secondary, subsurface_face_ids_secondary; save_forces=false)
+output_primary   = SingleAsteroidOutputSpec(output_times_primary;   subsurface_face_ids=[1, 2], save_forces=true)
+output_secondary = SingleAsteroidOutputSpec(output_times_secondary; subsurface_face_ids=[3])
 output = BinaryAsteroidOutputSpec(output_primary, output_secondary)
 ```
 """
@@ -166,26 +117,23 @@ struct BinaryAsteroidOutputSpec
 end
 
 function BinaryAsteroidOutputSpec(
-    output_times_primary          ::Vector{Float64},
-    subsurface_face_ids_primary   ::Vector{Int},
-    output_times_secondary        ::Vector{Float64},
-    subsurface_face_ids_secondary ::Vector{Int};
-    save_surface_temperature    ::Bool = true,
-    save_subsurface_temperature ::Bool = true,
-    save_face_forces            ::Bool = false,
-    save_forces                 ::Bool = false,
-    save_torques                ::Bool = false,
+    output_times_primary   ::AbstractVector{<:Real},
+    output_times_secondary ::AbstractVector{<:Real};
+    subsurface_face_ids_primary   ::AbstractVector{<:Integer} = Int[],
+    subsurface_face_ids_secondary ::AbstractVector{<:Integer} = Int[],
+    save_surface_temperature ::Bool = true,
+    save_face_forces         ::Bool = false,
+    save_forces              ::Bool = false,
+    save_torques             ::Bool = false,
 )
-    output_primary = SingleAsteroidOutputSpec(
-        output_times_primary, subsurface_face_ids_primary;
-        save_surface_temperature, save_subsurface_temperature, save_face_forces, save_forces, save_torques,
+    output_primary = SingleAsteroidOutputSpec(output_times_primary;
+        subsurface_face_ids = subsurface_face_ids_primary,
+        save_surface_temperature, save_face_forces, save_forces, save_torques,
     )
-
-    output_secondary = SingleAsteroidOutputSpec(
-        output_times_secondary, subsurface_face_ids_secondary;
-        save_surface_temperature, save_subsurface_temperature, save_face_forces, save_forces, save_torques,
+    output_secondary = SingleAsteroidOutputSpec(output_times_secondary;
+        subsurface_face_ids = subsurface_face_ids_secondary,
+        save_surface_temperature, save_face_forces, save_forces, save_torques,
     )
-
     BinaryAsteroidOutputSpec(output_primary, output_secondary)
 end
 
@@ -310,11 +258,11 @@ function _build_single_solution(
 
     depth_nodes            = state.problem.grid_params.Δz * collect(0:n_depth-1)
     surface_temperature    = output.save_surface_temperature    ? zeros(n_face, n_save) : nothing
-    subsurface_temperature = output.save_subsurface_temperature ? Dict{Int,Matrix{Float64}}(i => zeros(n_depth, n_save) for i in output.subsurface_face_ids) : nothing
+    subsurface_temperature = !isempty(output.subsurface_face_ids) ? Dict{Int,Matrix{Float64}}(i => zeros(n_depth, n_save) for i in output.subsurface_face_ids) : nothing
     face_forces            = output.save_face_forces            ? zeros(SVector{3,Float64}, n_face, n_save) : nothing
     forces                 = output.save_forces  ? zeros(SVector{3,Float64}, n_save) : nothing
     torques                = output.save_torques ? zeros(SVector{3,Float64}, n_save) : nothing
-    roughness_surface_temperature = output.save_roughness_surface_temperature ?
+    roughness_surface_temperature = !isempty(output.roughness_face_ids) ?
         Dict{Int,Matrix{Float64}}(i => zeros(_n_roughness_faces(state, i), n_save) for i in output.roughness_face_ids) : nothing
 
     SingleAsteroidThermoPhysicalSolution(
@@ -330,7 +278,7 @@ end
 # roughness models at all, or face `i` carries none, since there would be nothing to save.
 function _n_roughness_faces(state::SingleAsteroidThermoPhysicalState, i::Integer)
     isempty(state.roughness_states) && throw(ArgumentError(
-        "save_roughness_surface_temperature requires a shape with surface roughness (see `add_roughness_models!`)"
+        "roughness_face_ids requires a shape with surface roughness (see `add_roughness_models!`)"
     ))
     k = state.face_roughness_indices[i]
     k == 0 && throw(ArgumentError(
@@ -398,7 +346,7 @@ function record_timestep!(
         solution.surface_temperature[:, i_save] .= surface_temperature(state)
     end
 
-    if solution.output.save_subsurface_temperature
+    if !isempty(solution.output.subsurface_face_ids)
         for (i, T_sub) in solution.subsurface_temperature
             T_sub[:, i_save] .= state.temperature[:, i]
         end
@@ -408,7 +356,7 @@ function record_timestep!(
         solution.face_forces[:, i_save] .= state.face_forces
     end
 
-    if solution.output.save_roughness_surface_temperature
+    if !isempty(solution.output.roughness_face_ids)
         for (i, T_rough) in solution.roughness_surface_temperature
             rs = state.roughness_states[state.face_roughness_indices[i]]
             T_rough[:, i_save] .= surface_temperature(rs)
@@ -599,20 +547,20 @@ Export simulation results to CSV files in `dirpath`.
 Files written depend on the `output` specification:
 - `diagnostics.csv`            : always (`absorbed_power`, `emitted_power` at all timesteps)
 - `surface_temperature.csv`    : when `output.save_surface_temperature = true`
-- `subsurface_temperature.csv` : when `output.save_subsurface_temperature = true`
+- `subsurface_temperature.csv` : when `output.subsurface_face_ids` is non-empty
 - `thermal_face_forces.csv`    : when `output.save_face_forces = true`
 - `thermal_net_forces.csv`     : when `output.save_forces = true` or `output.save_torques = true`
-- `roughness_surface_temperature.csv` : when `output.save_roughness_surface_temperature = true`;
+- `roughness_surface_temperature.csv` : when `output.roughness_face_ids` is non-empty;
   long format with columns `time`, `face_id`, `sub_face_id`, `temperature`
 """
 function export_solution(dirpath, solution::SingleAsteroidThermoPhysicalSolution)
     mkpath(dirpath)
     _export_diagnostics(dirpath, solution)
     solution.output.save_surface_temperature    && _export_surface_temperature(dirpath, solution)
-    solution.output.save_subsurface_temperature && _export_subsurface_temperature(dirpath, solution)
+    !isempty(solution.output.subsurface_face_ids) && _export_subsurface_temperature(dirpath, solution)
     solution.output.save_face_forces            && _export_thermal_face_forces(dirpath, solution)
     (solution.output.save_forces || solution.output.save_torques) && _export_thermal_net_forces(dirpath, solution)
-    solution.output.save_roughness_surface_temperature && _export_roughness_surface_temperature(dirpath, solution)
+    !isempty(solution.output.roughness_face_ids) && _export_roughness_surface_temperature(dirpath, solution)
 end
 
 

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -131,7 +131,7 @@ problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params;
     with_self_shadowing = true,
     with_self_heating   = true,
 )
-output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
 solution = solve(problem, CrankNicolson();
     ephem               = ephem,
     output              = output,
@@ -175,8 +175,8 @@ Run a thermophysical simulation for a binary asteroid system.
 ```julia
 T_init = subsolar_temperature(ephem.r_sun[begin], R_vis, ε)
 output = BinaryAsteroidOutputSpec(
-    SingleAsteroidOutputSpec(output_times, subsurface_face_ids_pri),
-    SingleAsteroidOutputSpec(output_times, subsurface_face_ids_sec),
+    SingleAsteroidOutputSpec(output_times; subsurface_face_ids=subsurface_face_ids_pri),
+    SingleAsteroidOutputSpec(output_times; subsurface_face_ids=subsurface_face_ids_sec),
 )
 solution = solve(problem, CrankNicolson();
     ephem                         = ephem,

--- a/test/TPM_Didymos/TPM_Didymos.jl
+++ b/test/TPM_Didymos/TPM_Didymos.jl
@@ -131,8 +131,8 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Didymos fo
     subsurface_face_ids1 = [1, 2, 3, 4, 10]  # Face indices to save subsurface temperature of the primary
     subsurface_face_ids2 = [1, 2, 3, 4, 20]  # Face indices to save subsurface temperature of the secondary
     output = BinaryAsteroidOutputSpec(
-        SingleAsteroidOutputSpec(output_times, subsurface_face_ids1),
-        SingleAsteroidOutputSpec(output_times, subsurface_face_ids2),
+        SingleAsteroidOutputSpec(output_times; subsurface_face_ids=subsurface_face_ids1),
+        SingleAsteroidOutputSpec(output_times; subsurface_face_ids=subsurface_face_ids2),
     )
 
     solution = solve(problem, ExplicitEuler();

--- a/test/TPM_Ryugu/TPM_Ryugu.jl
+++ b/test/TPM_Ryugu/TPM_Ryugu.jl
@@ -105,7 +105,7 @@ See https://github.com/Astroshaper/Astroshaper-examples/tree/main/TPM_Ryugu for 
     ## --- Run TPM ---
     output_times        = ephem.times[end-n_step_in_cycle:end]  # Save temperature during the final rotation
     subsurface_face_ids = [1, 2, 3, 4, 10]  # Face indices to save subsurface temperature
-    output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+    output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
 
     solution = solve(problem, ExplicitEuler();
         ephem               = ephem,

--- a/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
+++ b/test/TPM_non-uniform_thermoparams/TPM_non-uniform_thermoparams.jl
@@ -111,7 +111,7 @@ Based on TPM_Ryugu test but with varying thermophysical properties.
     ## --- Run TPM ---
     output_times        = ephem.times[end-n_step_in_cycle:end]  # Save temperature during the final rotation
     subsurface_face_ids = [1, 2, 3, 4, 10]  # Face indices to save subsurface temperature
-    output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+    output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
 
     solution = solve(problem, ExplicitEuler();
         ephem               = ephem,

--- a/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
+++ b/test/TPM_zero-conductivity/TPM_zero-conductivity.jl
@@ -61,7 +61,7 @@ This test validates:
     ## --- Run TPM ---
     output_times        = ephem.times[end-n_step_in_cycle:end]  # Save temperature during the final rotation
     subsurface_face_ids = [1, 2]  # Face indices to save subsurface temperature
-    output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+    output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
 
     solution = solve(problem, ExplicitEuler();
         ephem               = ephem,

--- a/test/test_directional_radiance.jl
+++ b/test/test_directional_radiance.jl
@@ -38,9 +38,7 @@ Direction-dependent radiance and brightness temperature of rough facets:
         n_face = length(shape.faces)
         problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
             with_self_shadowing=false, with_self_heating=false)
-        output = SingleAsteroidOutputSpec(output_times, Int[];
-            save_subsurface_temperature=false,
-            roughness_face_ids=collect(1:n_face), save_roughness_surface_temperature=true)
+        output = SingleAsteroidOutputSpec(output_times; roughness_face_ids=collect(1:n_face))
         sol = solve(problem, CrankNicolson(); ephem, output, initial_temperature=200.0, show_progress=false)
         shape, problem, sol
     end
@@ -132,7 +130,7 @@ Direction-dependent radiance and brightness temperature of rough facets:
         shape_plain = load_shape_obj(path_obj)
         problem_plain = SingleAsteroidThermoPhysicalProblem(shape_plain, thermo_params, grid_params;
             with_self_shadowing=false, with_self_heating=false)
-        output_plain = SingleAsteroidOutputSpec(output_times, Int[]; save_subsurface_temperature=false)
+        output_plain = SingleAsteroidOutputSpec(output_times)
         sol_plain = solve(problem_plain, CrankNicolson(); ephem, output=output_plain,
             initial_temperature=200.0, show_progress=false)
         L_plain = directional_radiance(problem_plain, sol_plain, 1, d̂)
@@ -151,8 +149,7 @@ Direction-dependent radiance and brightness temperature of rough facets:
         add_roughness_models!(shape_part, create_shape_crater(0.4, 0.1; Nx=4, Ny=4), 1)
         problem_part = SingleAsteroidThermoPhysicalProblem(shape_part, thermo_params, grid_params;
             with_self_shadowing=false, with_self_heating=false)
-        output_part = SingleAsteroidOutputSpec(output_times, Int[]; save_subsurface_temperature=false,
-            roughness_face_ids=[1], save_roughness_surface_temperature=true)
+        output_part = SingleAsteroidOutputSpec(output_times; roughness_face_ids=[1])
         sol_part = solve(problem_part, CrankNicolson(); ephem, output=output_part,
             initial_temperature=200.0, show_progress=false)
         L_part = directional_radiance(problem_part, sol_part, 1, d̂)
@@ -165,8 +162,7 @@ Direction-dependent radiance and brightness temperature of rough facets:
         add_roughness_models!(shape, create_shape_crater(0.4, 0.1; Nx=4, Ny=4))
         problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params;
             with_self_shadowing=false, with_self_heating=false)
-        output = SingleAsteroidOutputSpec(output_times, Int[];
-            save_surface_temperature=false, save_subsurface_temperature=false)
+        output = SingleAsteroidOutputSpec(output_times; save_surface_temperature=false)
         sol = solve(problem, CrankNicolson(); ephem, output, initial_temperature=200.0, show_progress=false)
         @test_throws ArgumentError directional_radiance(problem, sol, 1, SVector(1.0, 0.0, 0.0))
     end

--- a/test/test_output_spec.jl
+++ b/test/test_output_spec.jl
@@ -1,10 +1,10 @@
 #=
 test_output_spec.jl
 
-Unit tests for SingleAsteroidOutputSpec and BinaryAsteroidOutputSpec types
-introduced in v0.2.0:
-- Construction and field access (including Bool flag defaults)
-- Inner constructor validation (ArgumentError when save_subsurface_temperature=true with empty subsurface_face_ids)
+Unit tests for SingleAsteroidOutputSpec and BinaryAsteroidOutputSpec types:
+- Keyword construction and defaults; face-selected outputs are switched on by listing faces
+- Input conversion (ranges and integer vectors of other element types)
+- Binary convenience constructor
 - _validate_output_spec: valid case (no error)
 - _validate_output_spec: invalid case (ArgumentError when output_times ⊄ ephem.times)
 =#
@@ -27,41 +27,54 @@ introduced in v0.2.0:
     output_times        = times[end-2:end]
     subsurface_face_ids = [1, 3, 5]
 
-    @testset "SingleAsteroidOutputSpec construction" begin
-        output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+    @testset "SingleAsteroidOutputSpec defaults" begin
+        output = SingleAsteroidOutputSpec(output_times)
 
         @test output isa SingleAsteroidOutputSpec
-        @test output.output_times        === output_times
-        @test output.subsurface_face_ids === subsurface_face_ids
+        @test output.output_times == output_times
 
-        # Default Bool flags
-        @test output.save_surface_temperature    == true
-        @test output.save_subsurface_temperature == true
-        @test output.save_face_forces            == false
-        @test output.save_forces                 == false
-        @test output.save_torques                == false
-        @test output.roughness_face_ids          == Int[]
-        @test output.save_roughness_surface_temperature == false
-
-        output_rough = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
-            roughness_face_ids = [1, 7], save_roughness_surface_temperature = true)
-        @test output_rough.roughness_face_ids == [1, 7]
-        @test output_rough.save_roughness_surface_temperature == true
+        # Only the surface temperature is saved by default
+        @test output.save_surface_temperature == true
+        @test output.subsurface_face_ids      == Int[]
+        @test output.roughness_face_ids       == Int[]
+        @test output.save_face_forces         == false
+        @test output.save_forces              == false
+        @test output.save_torques             == false
     end
 
-    @testset "SingleAsteroidOutputSpec inner constructor validation" begin
-        # save_subsurface_temperature=true with empty subsurface_face_ids → ArgumentError
-        @test_throws ArgumentError SingleAsteroidOutputSpec(output_times, Int[], true, true, false, true, true)
-        # save_subsurface_temperature=false with empty subsurface_face_ids → OK
-        @test_nowarn SingleAsteroidOutputSpec(output_times, Int[], true, false, false, true, true)
-        # save_roughness_surface_temperature=true with empty roughness_face_ids → ArgumentError
-        @test_throws ArgumentError SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
-            save_roughness_surface_temperature = true)
+    @testset "SingleAsteroidOutputSpec keywords" begin
+        output = SingleAsteroidOutputSpec(output_times;
+            save_surface_temperature = false,
+            subsurface_face_ids      = subsurface_face_ids,
+            roughness_face_ids       = [1, 7],
+            save_face_forces         = true,
+            save_forces              = true,
+            save_torques             = true,
+        )
+
+        @test output.save_surface_temperature == false
+        @test output.subsurface_face_ids      == subsurface_face_ids
+        @test output.roughness_face_ids       == [1, 7]
+        @test output.save_face_forces         == true
+        @test output.save_forces              == true
+        @test output.save_torques             == true
+    end
+
+    @testset "SingleAsteroidOutputSpec input conversion" begin
+        # Ranges and other integer element types are converted to the field types
+        output = SingleAsteroidOutputSpec(range(0.0, 100.0; length=n);
+            subsurface_face_ids = 1:3, roughness_face_ids = Int32[2, 4])
+
+        @test output.output_times        isa Vector{Float64}
+        @test output.subsurface_face_ids isa Vector{Int}
+        @test output.roughness_face_ids  isa Vector{Int}
+        @test output.subsurface_face_ids == [1, 2, 3]
+        @test output.roughness_face_ids  == [2, 4]
     end
 
     @testset "BinaryAsteroidOutputSpec construction" begin
-        spec1 = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
-        spec2 = SingleAsteroidOutputSpec(output_times, [2, 4])
+        spec1 = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
+        spec2 = SingleAsteroidOutputSpec(output_times; subsurface_face_ids=[2, 4])
         output   = BinaryAsteroidOutputSpec(spec1, spec2)
 
         @test output isa BinaryAsteroidOutputSpec
@@ -70,19 +83,19 @@ introduced in v0.2.0:
     end
 
     @testset "_validate_output_spec — valid (no error)" begin
-        output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+        output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
         @test_nowarn AsteroidThermoPhysicalModels._validate_output_spec(output, ephem)
     end
 
     @testset "_validate_output_spec — invalid single (ArgumentError: time not in ephem)" begin
         invalid_time  = times[end] + 1.0  # not in ephem.times
-        output_bad    = SingleAsteroidOutputSpec([times[1], invalid_time], subsurface_face_ids)
+        output_bad    = SingleAsteroidOutputSpec([times[1], invalid_time]; subsurface_face_ids)
         @test_throws ArgumentError AsteroidThermoPhysicalModels._validate_output_spec(output_bad, ephem)
     end
 
     @testset "_validate_output_spec — invalid single (ArgumentError: forces with no rotation matrices)" begin
         # save_forces=true requires R_body_to_inertial in ephemerides
-        output_with_forces = SingleAsteroidOutputSpec(output_times, subsurface_face_ids, true, true, false, true, false)
+        output_with_forces = SingleAsteroidOutputSpec(output_times; subsurface_face_ids, save_forces=true)
         @test_throws ArgumentError AsteroidThermoPhysicalModels._validate_output_spec(output_with_forces, ephem)
     end
 
@@ -92,8 +105,8 @@ introduced in v0.2.0:
         ephem_b = BinaryAsteroidEphemerides(times, r_sun, r_secondary, R_primary_to_secondary)
 
         output = BinaryAsteroidOutputSpec(
-            SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
-            SingleAsteroidOutputSpec(output_times, [2]),
+            SingleAsteroidOutputSpec(output_times; subsurface_face_ids),
+            SingleAsteroidOutputSpec(output_times; subsurface_face_ids=[2]),
         )
         @test_nowarn AsteroidThermoPhysicalModels._validate_output_spec(output, ephem_b)
     end
@@ -105,8 +118,8 @@ introduced in v0.2.0:
 
         invalid_time = times[end] + 1.0
         output = BinaryAsteroidOutputSpec(
-            SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
-            SingleAsteroidOutputSpec([invalid_time], [1]),
+            SingleAsteroidOutputSpec(output_times; subsurface_face_ids),
+            SingleAsteroidOutputSpec([invalid_time]; subsurface_face_ids=[1]),
         )
         @test_throws ArgumentError AsteroidThermoPhysicalModels._validate_output_spec(output, ephem_b)
     end
@@ -115,29 +128,26 @@ introduced in v0.2.0:
         output_times_s        = times[end-1:end]
         subsurface_face_ids_s = [2, 4]
 
-        output = BinaryAsteroidOutputSpec(
-            output_times, subsurface_face_ids,
-            output_times_s, subsurface_face_ids_s;
-            save_surface_temperature    = false,
-            save_subsurface_temperature = true,
-            save_face_forces            = true,
-            save_forces                 = false,
-            save_torques                = false,
+        output = BinaryAsteroidOutputSpec(output_times, output_times_s;
+            subsurface_face_ids_primary   = subsurface_face_ids,
+            subsurface_face_ids_secondary = subsurface_face_ids_s,
+            save_surface_temperature = false,
+            save_face_forces         = true,
+            save_forces              = false,
+            save_torques             = false,
         )
 
         @test output isa BinaryAsteroidOutputSpec
 
         # Each body gets the correct output_times and subsurface_face_ids
-        @test output.primary.output_times          === output_times
-        @test output.primary.subsurface_face_ids   === subsurface_face_ids
-        @test output.secondary.output_times        === output_times_s
-        @test output.secondary.subsurface_face_ids === subsurface_face_ids_s
+        @test output.primary.output_times          == output_times
+        @test output.primary.subsurface_face_ids   == subsurface_face_ids
+        @test output.secondary.output_times        == output_times_s
+        @test output.secondary.subsurface_face_ids == subsurface_face_ids_s
 
         # Shared Bool flags are propagated identically to both bodies
-        @test output.primary.save_surface_temperature    == false
-        @test output.secondary.save_surface_temperature  == false
-        @test output.primary.save_subsurface_temperature == true
-        @test output.secondary.save_subsurface_temperature == true
+        @test output.primary.save_surface_temperature   == false
+        @test output.secondary.save_surface_temperature == false
         @test output.primary.save_face_forces   == true
         @test output.secondary.save_face_forces == true
         @test output.primary.save_forces        == false

--- a/test/test_roughness_solve.jl
+++ b/test/test_roughness_solve.jl
@@ -60,10 +60,10 @@ End-to-end tests of `solve` on a `ShapeModel` with surface roughness:
     @testset "partial roughness: global-level outputs equal the plain run" begin
         times, ephem = make_ephem(2; with_rotation=false)
         output_times = times[end-n_step_cycle:end]
-        output = SingleAsteroidOutputSpec(output_times, [1, 7];
-            save_surface_temperature    = true,
-            save_subsurface_temperature = true,
-            save_face_forces            = true,
+        output = SingleAsteroidOutputSpec(output_times;
+            save_surface_temperature = true,
+            subsurface_face_ids      = [1, 7],
+            save_face_forces         = true,
         )
 
         shape_plain = load_shape_obj(path_obj)
@@ -95,12 +95,11 @@ End-to-end tests of `solve` on a `ShapeModel` with surface roughness:
     @testset "near-flat roughness reproduces the plain net force, torque and power" begin
         times, ephem = make_ephem(2; with_rotation=true)
         output_times = times[end-n_step_cycle:end]
-        output = SingleAsteroidOutputSpec(output_times, Int[];
-            save_surface_temperature    = false,
-            save_subsurface_temperature = false,
-            save_face_forces            = false,
-            save_forces                 = true,
-            save_torques                = true,
+        output = SingleAsteroidOutputSpec(output_times;
+            save_surface_temperature = false,
+            save_face_forces         = false,
+            save_forces              = true,
+            save_torques             = true,
         )
 
         shape_plain = load_shape_obj(path_obj)
@@ -128,10 +127,7 @@ End-to-end tests of `solve` on a `ShapeModel` with surface roughness:
     @testset "energy balance closes with roughness faces as representative patches" begin
         n_cycle = 10
         times, ephem = make_ephem(n_cycle; with_rotation=false)
-        output = SingleAsteroidOutputSpec(times[end:end], Int[];
-            save_surface_temperature    = true,
-            save_subsurface_temperature = false,
-        )
+        output = SingleAsteroidOutputSpec(times[end:end]; save_surface_temperature = true)
 
         shape_hier = load_shape_obj(path_obj)
         add_roughness_models!(shape_hier, roughness_model)
@@ -153,9 +149,7 @@ End-to-end tests of `solve` on a `ShapeModel` with surface roughness:
         shape_hier = load_shape_obj(path_obj)
         add_roughness_models!(shape_hier, roughness_model, 1)
         add_roughness_models!(shape_hier, roughness_model, 7)
-        output = SingleAsteroidOutputSpec(output_times, Int[];
-            save_subsurface_temperature = false,
-            roughness_face_ids = [7, 1], save_roughness_surface_temperature = true)
+        output = SingleAsteroidOutputSpec(output_times; roughness_face_ids = [7, 1])
         sol = solve(make_problem(shape_hier), CrankNicolson();
             ephem, output, initial_temperature=200.0, show_progress=false)
 
@@ -183,10 +177,8 @@ End-to-end tests of `solve` on a `ShapeModel` with surface roughness:
         # A roughness model flat to 1e-6 reproduces the smooth face's surface temperature
         shape_flat = load_shape_obj(path_obj)
         add_roughness_models!(shape_flat, create_shape_crater(0.4, 1e-6; Nx=4, Ny=4))
-        output_flat = SingleAsteroidOutputSpec(output_times, Int[];
-            save_subsurface_temperature = false,
-            roughness_face_ids = collect(1:length(shape_flat.faces)),
-            save_roughness_surface_temperature = true)
+        output_flat = SingleAsteroidOutputSpec(output_times;
+            roughness_face_ids = collect(1:length(shape_flat.faces)))
         sol_flat = solve(make_problem(shape_flat), CrankNicolson();
             ephem, output=output_flat, initial_temperature=200.0, show_progress=false)
         for (i, T_rough) in sol_flat.roughness_surface_temperature
@@ -194,9 +186,7 @@ End-to-end tests of `solve` on a `ShapeModel` with surface roughness:
         end
 
         # Requesting a face without a roughness model, or a plain ShapeModel, is an error
-        output_bad = SingleAsteroidOutputSpec(output_times, Int[];
-            save_subsurface_temperature = false,
-            roughness_face_ids = [2], save_roughness_surface_temperature = true)
+        output_bad = SingleAsteroidOutputSpec(output_times; roughness_face_ids = [2])
         @test_throws ArgumentError solve(make_problem(shape_hier), CrankNicolson();
             ephem, output=output_bad, initial_temperature=200.0, show_progress=false)
         shape_plain = load_shape_obj(path_obj)
@@ -207,12 +197,12 @@ End-to-end tests of `solve` on a `ShapeModel` with surface roughness:
     @testset "export_solution and show_progress" begin
         times, ephem = make_ephem(1; with_rotation=true)
         output_times = times[end-5:end]
-        output = SingleAsteroidOutputSpec(output_times, [1];
-            save_surface_temperature    = true,
-            save_subsurface_temperature = true,
-            save_face_forces            = true,
-            save_forces                 = true,
-            save_torques                = true,
+        output = SingleAsteroidOutputSpec(output_times;
+            save_surface_temperature = true,
+            subsurface_face_ids      = [1],
+            save_face_forces         = true,
+            save_forces              = true,
+            save_torques             = true,
         )
 
         shape_hier = load_shape_obj(path_obj)

--- a/test/test_tpm_with_force.jl
+++ b/test/test_tpm_with_force.jl
@@ -57,7 +57,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
             with_self_heating   = false,
         )
 
-        output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids, true, true, false, true, true)
+        output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids, save_forces=true, save_torques=true)
         solution = solve(problem, CrankNicolson();
             ephem               = ephem,
             output              = output,
@@ -99,10 +99,9 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         )
         n_face = length(shape.faces)
 
-        output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids;
-            save_surface_temperature    = false,
-            save_subsurface_temperature = false,
-            save_face_forces            = true,
+        output = SingleAsteroidOutputSpec(output_times;
+            save_surface_temperature = false,
+            save_face_forces         = true,
         )
         solution = solve(problem, CrankNicolson();
             ephem               = ephem_no_rot,
@@ -147,8 +146,8 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
         )
 
         output = BinaryAsteroidOutputSpec(
-            SingleAsteroidOutputSpec(output_times, subsurface_face_ids, true, true, false, true, true),
-            SingleAsteroidOutputSpec(output_times, subsurface_face_ids, true, true, false, true, true),
+            SingleAsteroidOutputSpec(output_times; subsurface_face_ids, save_forces=true, save_torques=true),
+            SingleAsteroidOutputSpec(output_times; subsurface_face_ids, save_forces=true, save_torques=true),
         )
         solution = solve(problem, CrankNicolson();
             ephem                         = ephem,
@@ -184,7 +183,7 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
                 with_self_shadowing=false, with_self_heating=false),
             ExplicitEuler();
             ephem               = SingleAsteroidEphemerides(times, r_sun),
-            output              = SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
+            output              = SingleAsteroidOutputSpec(output_times; subsurface_face_ids),
             initial_temperature = 200.0,
             show_progress       = false,
         )
@@ -213,8 +212,8 @@ Covers: _alloc_solution (with forces/torques), record_timestep! (with R),
                 [Matrix{Float64}(I, 3, 3) for _ in times],
             ),
             output = BinaryAsteroidOutputSpec(
-                SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
-                SingleAsteroidOutputSpec(output_times, subsurface_face_ids),
+                SingleAsteroidOutputSpec(output_times; subsurface_face_ids),
+                SingleAsteroidOutputSpec(output_times; subsurface_face_ids),
             ),
             initial_temperature_primary   = 200.0,
             initial_temperature_secondary = 200.0,

--- a/test/thermal_radiation.jl
+++ b/test/thermal_radiation.jl
@@ -88,7 +88,7 @@ This test validates:
 
     output_times        = ephem.times[end-nsteps_in_cycle:end]  # Save temperature during the final rotation
     subsurface_face_ids = [49, 340, 648]  # Face indices to save subsurface temperature
-    output = SingleAsteroidOutputSpec(output_times, subsurface_face_ids)
+    output = SingleAsteroidOutputSpec(output_times; subsurface_face_ids)
 
     solution = solve(problem, ExplicitEuler();
         ephem               = ephem,


### PR DESCRIPTION
## Summary

Breaking API cleanup before the v0.3.0 release. `SingleAsteroidOutputSpec` had grown asymmetric after #235: `subsurface_face_ids` was positional and required even when no subsurface output was wanted, `roughness_face_ids` was a keyword, and each list came with a `save_*` flag whose only valid combinations were "non-empty list + `true`" and "anything + `false`" (the default `save_subsurface_temperature = true` with an empty list raised).

Every face-selected output is now a keyword list that is on when non-empty:

```julia
SingleAsteroidOutputSpec(output_times;
    save_surface_temperature = true,
    subsurface_face_ids      = Int[],   # non-empty → subsurface_temperature is saved
    roughness_face_ids       = Int[],   # non-empty → roughness_surface_temperature is saved
    save_face_forces         = false,
    save_forces              = false,
    save_torques             = false,
)
```

- `save_subsurface_temperature` / `save_roughness_surface_temperature` fields and keywords are removed; the invalid combinations disappear with them, and the struct loses two fields
- The positional constructors are removed
- `BinaryAsteroidOutputSpec(output_times_primary, output_times_secondary; subsurface_face_ids_primary, subsurface_face_ids_secondary, save_*...)` replaces the four-positional convenience constructor; `BinaryAsteroidOutputSpec(primary, secondary)` is unchanged
- Inputs are accepted as `AbstractVector{<:Real}` / `AbstractVector{<:Integer}` and stored as `Vector{Float64}` / `Vector{Int}`, so ranges and other integer element types work (as the `*Ephemerides` constructors already do)
- Internal reads of the flags become `!isempty(output.*_face_ids)` in the solution allocation, `record_timestep!` and `export_solution`

The distinction is now explicit: quantities recorded for every face are switched by a `save_*` flag, quantities recorded for selected faces by listing the faces.

### Docs

- `CHANGELOG.md` (`[0.3.0]` Changed, **Breaking**, with before/after), `docs/src/migration.md` (new section), `docs/src/examples.md` and `README.md` migrated, `solve` docstring examples updated

## Test plan

- [x] `test/test_output_spec.jl` rewritten for the new API: defaults (only the surface temperature by default), keywords, input conversion (range, `1:3`, `Int32[]`), binary base and convenience constructors, `_validate_output_spec` cases
- [x] All other call sites migrated (`test_roughness_solve.jl`, `test_directional_radiance.jl`, `test_tpm_with_force.jl`, `thermal_radiation.jl`, the four `TPM_*` end-to-end tests)
- [x] Full `Pkg.test()` passes locally (Julia 1.12.6, AsteroidShapeModels 0.6.0)

## Notes

- The Torifune analysis environment is pinned to `9cd2c6f` and unaffected; its notebooks will need the new `OutputSpec` calls when they move to v0.3.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)