### PR TITLE
refactor!: raise `ArgumentError` for errors caused by the inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,11 @@ grid_params.Δz
 
 ### Changed
 
+- **Breaking**: errors caused by the inputs raise `ArgumentError` instead of a plain
+  `ErrorException`, matching AsteroidShapeModels.jl v0.6: a missing face visibility graph when
+  `with_self_shadowing` / `with_self_heating` is enabled, a missing BVH when
+  `with_mutual_shadowing` is enabled, and a time step that violates the explicit Euler
+  stability limit (λ ≥ 0.5). Code that catches `ErrorException` for these cases must be updated
 - **Breaking**: `SingleAsteroidOutputSpec` selects the face-specific outputs by face lists
   alone. `subsurface_face_ids` moves from a positional argument to a keyword, and the
   `save_subsurface_temperature` / `save_roughness_surface_temperature` flags are removed: a

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -223,10 +223,10 @@ end
 # when the graph was removed from the (mutable) shape afterwards — which must fail loudly
 # rather than silently drop the term that depends on it.
 function _require_face_visibility_graph(shape::ShapeModel, flag::AbstractString)
-    has_face_visibility_graph(shape) || error(
+    has_face_visibility_graph(shape) || throw(ArgumentError(
         "face_visibility_graph must be built when `$flag` is enabled. " *
         "Use `build_face_visibility_graph!(shape)` or load the shape with `with_face_visibility=true`."
-    )
+    ))
     return nothing
 end
 
@@ -354,10 +354,10 @@ function update_flux_sun!(
     if state.problem.with_mutual_shadowing
         # Check BVH availability
         if !has_bvh(state.primary.problem.shape) || !has_bvh(state.secondary.problem.shape)
-            error(
-                "BVH must be built for both shapes when MUTUAL_SHADOWING is enabled. " *
+            throw(ArgumentError(
+                "BVH must be built for both shapes when `with_mutual_shadowing` is enabled. " *
                 "Use `build_bvh!(shape)` or load shapes with `with_bvh=true`."
-            )
+            ))
         end
 
         shape1 = state.primary.problem.shape

--- a/src/heat_conduction.jl
+++ b/src/heat_conduction.jl
@@ -183,7 +183,7 @@ The method is stable only when λ < 0.5. If this condition is violated, an error
 - Consider using implicit methods for larger time steps
 
 # Errors
-- Throws an error if λ ≥ 0.5 (stability violation)
+- Throws an `ArgumentError` if λ ≥ 0.5 (stability violation)
 """
 function explicit_euler!(state::SingleAsteroidThermoPhysicalState, Δt)
     T = state.temperature
@@ -198,7 +198,7 @@ function explicit_euler!(state::SingleAsteroidThermoPhysicalState, Δt)
 
         α = thermal_diffusivity(k, ρ, Cₚ)  # Thermal diffusivity [m²/s]
         λ = α * Δt / Δz^2
-        λ ≥ 0.5 && error("Explicit Euler method is unstable because λ = αΔt/Δz² = $λ (must be < 0.5). Consider reducing time step from Δt = $Δt or using an implicit solver.")
+        λ ≥ 0.5 && throw(ArgumentError("Explicit Euler method is unstable because λ = αΔt/Δz² = $λ (must be < 0.5). Consider reducing time step from Δt = $Δt or using an implicit solver."))
 
         for i_depth in 2:(n_depth-1)
             state.solver_cache.x[i_depth] = (1-2λ)*T[i_depth, i_face] + λ*(T[i_depth+1, i_face] + T[i_depth-1, i_face])  # Predict temperature at next time step

--- a/test/heat_conduction_1D.jl
+++ b/test/heat_conduction_1D.jl
@@ -133,4 +133,11 @@ Tests for 1D heat conduction solvers:
         println("    - Implicit Euler vs. Isothermal analytical solution: ", δ_max_IE)
         println("    - Crank-Nicolson vs. Isothermal analytical solution: ", δ_max_CN)
     end
+    @testset "explicit Euler rejects an unstable time step" begin
+        # λ = αΔt/Δz² ≥ 0.5 is an input error (the time step), so it raises an ArgumentError
+        α = k / (ρ * Cₚ)
+        Δt_unstable = 0.5 * grid_params.Δz^2 / α
+        @test_throws ArgumentError AsteroidThermoPhysicalModels.explicit_euler!(state_EE, Δt_unstable)
+        @test_nowarn AsteroidThermoPhysicalModels.explicit_euler!(state_EE, 0.9 * Δt_unstable)
+    end
 end

--- a/test/test_roughness_state.jl
+++ b/test/test_roughness_state.jl
@@ -351,7 +351,7 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
 
         shape_hier.face_visibility_graph = nothing
         r☉ = SVector(1.0, 0.0, 0.0) * AsteroidThermoPhysicalModels.au2m
-        @test_throws ErrorException AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+        @test_throws ArgumentError AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
     end
 
     @testset "update_flux_scat_single! / update_flux_rad_single! (global level)" begin

--- a/test/test_self_heating_guards.jl
+++ b/test/test_self_heating_guards.jl
@@ -1,8 +1,8 @@
 #=
 test_self_heating_guards.jl
 
-The terms that depend on the face visibility graph must fail loudly when the graph is missing
-and the flag that needs it is enabled, and the re-absorption recoil term must follow
+The terms that depend on the face visibility graph (or, for mutual shadowing, the BVH) must
+fail loudly when that data is missing and the flag that needs it is enabled, and the re-absorption recoil term must follow
 `with_self_heating` rather than the mere presence of the graph.
 =#
 
@@ -50,8 +50,8 @@ and the flag that needs it is enabled, and the re-absorption recoil term must fo
         state = make_state(with_self_shadowing=false, with_self_heating=true)
         AsteroidThermoPhysicalModels.update_flux_sun!(state, r☉)
         state.problem.shape.face_visibility_graph = nothing
-        @test_throws ErrorException AsteroidThermoPhysicalModels.update_flux_scat_single!(state)
-        @test_throws ErrorException AsteroidThermoPhysicalModels.update_flux_rad_single!(state)
+        @test_throws ArgumentError AsteroidThermoPhysicalModels.update_flux_scat_single!(state)
+        @test_throws ArgumentError AsteroidThermoPhysicalModels.update_flux_rad_single!(state)
     end
 
     @testset "scattering and radiation stay silent when self-heating is off" begin
@@ -89,6 +89,28 @@ and the flag that needs it is enabled, and the re-absorption recoil term must fo
         state = make_state(with_self_shadowing=false, with_self_heating=true)
         AsteroidThermoPhysicalModels.update_flux_all!(state, r☉)
         state.problem.shape.face_visibility_graph = nothing
-        @test_throws ErrorException AsteroidThermoPhysicalModels.update_thermal_force!(state)
+        @test_throws ArgumentError AsteroidThermoPhysicalModels.update_thermal_force!(state)
+    end
+    @testset "mutual shadowing raises without the BVH" begin
+        # The binary problem builds the BVH, but the shapes are mutable and may lose it
+        # afterwards; the eclipse test must then fail loudly rather than be skipped.
+        path_obj = joinpath(@__DIR__, "shape", "icosahedron.obj")
+        shape1 = load_shape_obj(path_obj; scale=1000)
+        shape2 = load_shape_obj(path_obj; scale=500)
+        problem = BinaryAsteroidThermoPhysicalProblem((shape1, shape2), thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=false,
+            with_mutual_shadowing=true, with_mutual_heating=false)
+        state = AsteroidThermoPhysicalModels._build_binary_state(problem, CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state, 250.0)
+
+        r☉₁ = r☉
+        r₁₂ = SVector(5000.0, 0.0, 0.0)
+        R₁₂ = SMatrix{3,3,Float64}(I)
+        r☉₂ = R₁₂ * (r☉₁ - r₁₂)
+        r₂₁ = -R₁₂ * r₁₂
+        @test_nowarn AsteroidThermoPhysicalModels.update_flux_sun!(state, r☉₁, r☉₂, r₁₂, r₂₁, R₁₂, R₁₂')
+
+        shape2.bvh = nothing
+        @test_throws ArgumentError AsteroidThermoPhysicalModels.update_flux_sun!(state, r☉₁, r☉₂, r₁₂, r₂₁, R₁₂, R₁₂')
     end
 end


### PR DESCRIPTION
## Summary

Breaking cleanup before the v0.3.0 release (step 1.5 (b)). Errors that a user can fix by changing the inputs were a mix of plain `error(...)` (`ErrorException`) and `ArgumentError`. Align the remaining three with AsteroidShapeModels.jl v0.6, which moved its input checks to `ArgumentError` / `DimensionMismatch` in #71:

| Site | Before | After |
|---|---|---|
| `_require_face_visibility_graph` — visibility graph missing while `with_self_shadowing` / `with_self_heating` is on | `error` | `ArgumentError` |
| Binary `update_flux_sun!` — BVH missing while `with_mutual_shadowing` is on | `error` | `ArgumentError` (message now names `with_mutual_shadowing`) |
| `explicit_euler!` — λ = αΔt/Δz² ≥ 0.5 | `error` | `ArgumentError` |

Unknown solver cache and unimplemented boundary condition are internal inconsistencies and keep `error`. `OutputSpec`, `ThermoParams`, ephemerides and roughness checks already raised `ArgumentError` / `DimensionMismatch`.

## Test plan

- [x] The four `@test_throws ErrorException` assertions (`test_self_heating_guards.jl`, `test_roughness_state.jl`) now assert `ArgumentError`
- [x] Two paths that had no test get one: `heat_conduction_1D.jl` checks that Δt at the stability limit raises and 0.9× of it runs; `test_self_heating_guards.jl` checks that the binary solar flux update runs with the BVH and raises `ArgumentError` once `shape.bvh` is removed
- [x] Full `Pkg.test()` passes locally (Julia 1.12.6, AsteroidShapeModels 0.6.0)

CHANGELOG: `[0.3.0]` Changed, **Breaking**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)