### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0] - TBD
+## [0.3.0] - 2026-09-09
 
 This release adds **surface roughness** to the thermophysical model, on top of
 AsteroidShapeModels.jl v0.6: a facet can carry a small roughness model (e.g. a spherical crater)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AsteroidThermoPhysicalModels"
 uuid = "ab46f4a3-3c83-4d86-98d6-41a8b1a2e76e"
 authors = ["Masanori Kanamaru"]
-version = "0.3.0-DEV"
+version = "0.3.0"
 
 [deps]
 AsteroidShapeModels = "a7943d8e-5d65-4248-ae23-0082f5115a05"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ pkg> add AsteroidThermoPhysicalModels
 - **Self-Shadowing**: Local shadows cast by topography
 - **Self-Heating**: Re-absorption of scattered and radiated photons by surrounding facets
 - **Binary Systems**: Support for mutual shadowing (eclipses) and mutual heating between primary and secondary bodies
+- **Surface Roughness**: Facets carry roughness models (e.g. spherical craters) solved as thermophysical models of their own, with self-shadowing and self-heating inside the roughness model — thermal-infrared beaming in the forces and in the radiance
 
 ### Shape Models
 - Supports Wavefront OBJ format (*.obj)
@@ -46,43 +47,35 @@ pkg> add AsteroidThermoPhysicalModels
 - **Yarkovsky Effect**: Orbital perturbation due to asymmetric thermal emission
 - **YORP Effect**: Rotational perturbation due to asymmetric thermal emission
 
-## 🆕 What's New in v0.2.x
+### Observables
+- **Direction-dependent radiance and brightness temperature** of every facet towards an observer, total or at a given wavelength, for comparison with thermal-infrared images
 
-### v0.2.1
+## 🆕 What's New in v0.3.x
 
-- `*Ephemerides` constructors now accept `AbstractRange` for `times` — no need to call `collect` beforehand
-- `*Ephemerides` constructors now auto-convert plain arrays to `SVector`/`SMatrix` — no need to import `StaticArrays`
+### v0.3.0
 
-### v0.2.0
-
-This release introduces a **Problem-Solver API** inspired by `DifferentialEquations.jl`, replacing the old `run_TPM!` function.
-
-### API Redesign (Breaking)
+This release adds **surface roughness** on top of `AsteroidShapeModels.jl` v0.6: a facet can carry a small roughness model (e.g. a spherical crater) that is solved as a thermophysical model of its own, which produces thermal-infrared beaming in the recorded forces and in the new direction-dependent radiance.
 
 ```julia
-# v0.1.x
-ephem  = (time = times, sun = r_sun)   # NamedTuple
-stpm   = SingleAsteroidThermoPhysicalModel(shape, thermo_params; ...)
-result = run_TPM!(stpm, ephem, times_to_save, face_ID)
+shape  = load_shape_obj("shape.obj"; scale=1000)
+crater = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)   # radius 0.4, depth 0.1, on a 1 × 1 patch
+add_roughness_models!(shape, crater)                  # every facet, or add_roughness_models!(shape, crater, face_idx)
 
-# v0.2.0
-ephem   = SingleAsteroidEphemerides(times, r_sun)
-problem = SingleAsteroidThermoPhysicalProblem(shape, thermo_params; ...)
-output  = SingleAsteroidOutputSpec(output_times;
-    save_surface_temperature = true,
-    subsurface_face_ids      = subsurface_face_ids,
-    save_face_forces            = false,
-    save_forces                 = false,  # true requires R_body_to_inertial in ephem
-    save_torques                = false,
-)
-solution = solve(problem, CrankNicolson();
-    ephem               = ephem,
-    output              = output,
-    initial_temperature = 200.0,
-)
+problem  = SingleAsteroidThermoPhysicalProblem(shape, thermo_params, grid_params; with_self_shadowing=true, with_self_heating=true)
+output   = SingleAsteroidOutputSpec(output_times; roughness_face_ids=1:length(shape.faces))
+solution = solve(problem, CrankNicolson(); ephem=ephem, output=output, initial_temperature=200.0)
+
+T_b = brightness_temperature(problem, solution, i_save, d̂_observer; λ=10e-6)   # per facet, towards the observer [K]
 ```
 
-See the [Migration Guide](CHANGELOG.md#migration-guide) and [CHANGELOG](CHANGELOG.md) for details.
+**Breaking changes** (see the [Migration Guide](https://astroshaper.github.io/AsteroidThermoPhysicalModels.jl/stable/migration/)):
+
+- `ThermoParams` holds material properties only; the depth grid moves to the new `GridParams`, a third positional argument of the problem constructors
+- `SingleAsteroidOutputSpec(output_times; subsurface_face_ids, roughness_face_ids, save_*...)` is keyword-only; face-specific outputs are switched on by listing faces
+- Requires `AsteroidShapeModels.jl` v0.6 (`HierarchicalShapeModel` no longer exists)
+- Input errors raise `ArgumentError`
+
+**Results that change**: the net thermal force on non-spherical shapes was biased by a radial projection up to v0.2.1 (about 7 % in magnitude and 6° in direction on Ryugu); recompute archived net forces with v0.3.0.
 
 ## 🌟 Example
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,10 +78,6 @@ Redesign the API around a Problem-Solver pattern inspired by `DifferentialEquati
 - [x] **API Cleanup**
   - [x] Remove `subsolar_temperature(r☉, params)` overload; use the explicit scalar form `subsolar_temperature(r☉, R_vis, ε)` instead
 
----
-**↓ Planned Releases ↓**
----
-
 ## v0.2.1 - Patch Fixes (Released: 2026-06-26)
 
 Non-breaking fixes and convenience improvements before the v0.3.0 surface roughness work.
@@ -91,19 +87,26 @@ Non-breaking fixes and convenience improvements before the v0.3.0 surface roughn
 - [x] **`*Ephemerides` auto-conversion** — constructors accept plain `Vector` inputs for position and rotation fields and convert to `SVector`/`SMatrix` internally; no need to import `StaticArrays` at the call site
 - [x] **Test prefix cleanup** — remove unnecessary `AsteroidThermoPhysicalModels.` prefixes from exported symbols in test files
 
-## v0.3.0 - Surface Roughness Support + ThermoParams Redesign (Target: 2026)
+## v0.3.0 - Surface Roughness Support + ThermoParams Redesign (Released: 2026-09-09)
 
-Introduce thermophysical modeling of surface roughness using `HierarchicalShapeModel` from `AsteroidShapeModels.jl`. This release also redesigns `ThermoParams` to separate material properties from numerical grid settings — a prerequisite for clean per-face material access in the roughness model.
+Thermophysical modeling of surface roughness on top of `AsteroidShapeModels.jl` v0.6, where a facet of a `ShapeModel` can carry a roughness model (e.g. a spherical crater) that is solved as a thermophysical model of its own. This release also separates `ThermoParams` (material) from `GridParams` (depth grid), makes the output specification keyword-only, and corrects two long-standing errors in the net thermal force and the thermal radiation flux.
 
-- [x] **`ThermoParams` / `GridParams` redesign** (breaking) — PR #218: separate thermophysical material properties (`ThermoParams`) from numerical depth-grid settings (`GridParams`)
+- [x] **`ThermoParams` / `GridParams` redesign** (breaking) — #218
+- [x] **Surface roughness** — state with independent sub-facet states (#222), global-level fluxes and heat conduction (#223, #225, #226), sub-facet illumination, self-heating with external irradiation, and heat conduction in the local frame of each facet (#227, #229, #231), thermal force of the sub-facets summed onto the parent facet as a representative patch (#233), `solve` end to end (#234)
+- [x] **Roughness surface temperatures recorded** (`roughness_face_ids`, `roughness_surface_temperature.csv`) — #235
+- [x] **Direction-dependent radiance and brightness temperature** of rough facets (thermal-infrared beaming) for image comparison — #236
+- [x] **Migration to `AsteroidShapeModels.jl` v0.6** (breaking) — #238: `HierarchicalShapeModel` is gone, roughness lives on `ShapeModel`; the state type is unified
+- [x] **Keyword-only `SingleAsteroidOutputSpec`** (breaking) — #239: face-specific outputs are selected by face lists
+- [x] **`ArgumentError` for input errors** (breaking) — #240
+- [x] **Fixes**: self-heating silently disabled without a visibility graph (#222), guards and re-absorption flag (#228), `flux_rad` reflectance (#230), net thermal force projection (#232)
 
-- [x] **Roughness-aware problem type** — PR #222: `SingleAsteroidThermoPhysicalProblem` accepts a `HierarchicalShapeModel`, and the new `HierarchicalSingleAsteroidThermoPhysicalState` holds an independent sub-face state (illumination, flux, temperature, thermal force) for each roughness-carrying face
+---
+**↓ Planned Releases ↓**
+---
 
-- [ ] **Sub-face flux and temperature calculations**: compute solar flux, self-heating, and 1D heat conduction on sub-faces in their local coordinate frames
+## v0.3.1 - Multi-threading, Solver Quality and Extended I/O (Target: 2026)
 
-- [ ] **Global aggregation**: transform sub-face thermal forces to the global frame and accumulate into body-level force and torque
-
-## v0.3.1 - Solver Quality and Extended I/O (Target: 2026)
+- [ ] **Multi-threading** of the sub-facet loops and the global heat conduction — a roughness run on a 9k-facet shape with 4×4 craters takes about 50 minutes single-threaded (3.5 hours with 8×8); parameter surveys need an order of magnitude less
 
 - [ ] **Heat conduction solver validation**
   - [ ] Validate numerical methods against analytical solutions
@@ -129,7 +132,6 @@ Introduce thermophysical modeling of surface roughness using `HierarchicalShapeM
 ## v0.5.0 - Performance Optimizations (Target: 2027)
 
 - [ ] **Computational Enhancements**
-  - [ ] Multi-threading support
   - [ ] GPU acceleration
   - [ ] Memory optimization
 


### PR DESCRIPTION
## Summary

Release v0.3.0 — surface roughness on top of AsteroidShapeModels.jl v0.6, `ThermoParams` / `GridParams` split, keyword-only `OutputSpec`, and the net-force / `flux_rad` corrections. Multi-threading (remaining item A) goes to v0.3.1.

- `CHANGELOG.md`: `[0.3.0] - 2026-09-09`
- `ROADMAP.md`: v0.3.0 marked released with the delivered items and PRs; the "Planned Releases" divider moved below it; multi-threading moved from v0.5.0 to v0.3.1
- `Project.toml`: `0.3.0-DEV` → `0.3.0`
- `README.md`: *What's New in v0.3.x* replaces the v0.2.x section (roughness example, breaking changes, results that change); *Features* gains Surface Roughness and Observables

After merging: open the `Release v0.3.0` issue with `@JuliaRegistrator register` and the release notes, per the release procedure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)