### PR TITLE
feat: directional external irradiation of the roughness sub-facets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **The radiation a roughness model receives from the other facets is now directional.**
+  Up to v0.3.0 the sub-facets of a roughness model received the flux their parent facet
+  receives from the other facets (the smooth-surface `flux_scat` / `flux_rad`) spread
+  isotropically by their sky view factor. Now, for every facet `j` visible from the parent,
+  the emission of `j` *towards the parent* is evaluated — from the sub-facets of `j`'s own
+  roughness model that face the parent, i.e. with thermal-infrared beaming, or as a Lambertian
+  face when `j` is smooth — and distributed over the sub-facets of the parent that see `j`.
+  The sub-facet visibilities of every visible pair are precomputed when the state is built
+  (`RoughnessNeighbours`). Results of runs with surface roughness and `with_self_heating =
+  true` change on concave shapes (nothing changes on convex shapes, where no facet sees
+  another); a flat roughness model reproduces the previous result. The global-level fluxes
+  are unchanged. Cost: about +6 % of a step for a 1000-sub-facet model (+20 % for a
+  32-sub-facet one), plus a few seconds of precomputation
+
 ## [0.3.0] - 2026-09-09
 
 This release adds **surface roughness** to the thermophysical model, on top of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`RoughnessNeighbours`). Results of runs with surface roughness and `with_self_heating =
   true` change on concave shapes (nothing changes on convex shapes, where no facet sees
   another); a flat roughness model reproduces the previous result. The global-level fluxes
-  are unchanged. Cost: about +6 % of a step for a 1000-sub-facet model (+20 % for a
-  32-sub-facet one), plus a few seconds of precomputation
+  are unchanged. Cost: proportional to the number of visible pairs of rough facets times the
+  number of sub-facets — about 15 µs per pair and time step for a 1000-sub-facet model, and
+  0.5 ms per pair for the precomputation of the masks. This is a few percent of a step on a
+  mostly convex body, where only a few facets see each other, but dominates it on a strongly
+  concave one (2048 facets seeing 560 others each: 16 s per step, 9 min of precomputation)
 
 ## [0.3.0] - 2026-09-09
 

--- a/docs/src/physical_model.md
+++ b/docs/src/physical_model.md
@@ -165,6 +165,26 @@ where ``\mathbf{f}_j`` and ``a_j`` are the force and area of sub-facet ``j`` in 
 
 When self-heating is enabled, the photons that leave the roughness model towards the sky and are intercepted by other facets ``k`` of the global shape are accounted for as for a smooth facet, taking the emission of the patch as isotropic: the power ``P_{\mathrm{sky},i} = (A_i / A_\mathrm{proj}) \sum_j E_j a_j f_{\mathrm{sky},j}`` that escapes the model, with ``f_{\mathrm{sky},j}`` the sky view factor of sub-facet ``j``, contributes ``(P_{\mathrm{sky},i} / c) \sum_k f_{ik} \hat{\mathbf{d}}_{ik}``.
 
+### Irradiation of a roughness model by the other facets
+
+A facet ``i`` that carries a roughness model receives, on its sub-facets ``m``, the scattered sunlight and the thermal radiation of every facet ``j`` visible from ``i``. The same far-field approximation as the view factor is used — both facets are small compared to their distance, so every sub-facet of ``j`` sees every sub-facet of ``i`` along the single direction ``\hat{\boldsymbol{d}}_{ij}`` — and the exchange separates into an emitter side and a receiver side.
+
+The emission of ``j`` towards ``i`` is that of its own roughness model in the direction ``\hat{\boldsymbol{d}}_{ji}``, per unit area of the model's reference plane projected onto that direction:
+
+```math
+E_j(\hat{\boldsymbol{d}}_{ji}) = \frac{1}{A_\mathrm{proj}\cos\theta_{ji}} \sum_n V_n(\hat{\boldsymbol{d}}_{ji})\,(\hat{\boldsymbol{n}}_n \cdot \hat{\boldsymbol{d}}_{ji})^+ \, E_n \, a_n
+```
+
+where ``V_n`` tells whether sub-facet ``n`` of ``j`` is seen from ``\hat{\boldsymbol{d}}_{ji}`` (it may be hidden by the model's own walls), ``E_n`` is ``\varepsilon\sigma T_n^4`` for thermal radiation and ``R_\mathrm{vis} F_{\mathrm{sun},n}`` for reflected sunlight (single scattering), and ``\cos\theta_{ji}`` is the inclination of ``\hat{\boldsymbol{d}}_{ji}`` to the reference plane. A hot sunlit wall that faces ``i`` makes ``E_j`` larger than the Lambertian ``\varepsilon\sigma T_j^4`` of the smooth facet — thermal-infrared beaming — and a shaded wall makes it smaller. A facet without a roughness model radiates as a Lambertian face.
+
+The irradiance reaching ``i`` is ``F_{ij} = E_j(\hat{\boldsymbol{d}}_{ji}) f_{ij}``, the same form as the smooth-surface term ``\varepsilon\sigma T_j^4 f_{ij}``. It is distributed over the sub-facets of ``i`` that see ``j``, each by its own inclination:
+
+```math
+F_m \mathrel{+}= \frac{F_{ij}}{\cos\theta_{ij}} \, V_m(\hat{\boldsymbol{d}}_{ij}) \, (\hat{\boldsymbol{n}}_m \cdot \hat{\boldsymbol{d}}_{ij})^+
+```
+
+so that the wall facing ``j`` is heated and the wall behind it is not — the same rule as for the sunlight, with ``F_{ij}`` in place of the solar flux. The power received, ``\sum_m F_m a_m``, equals ``F_{ij} A_\mathrm{proj}`` up to the shadowing discretisation of the sub-facets. The sub-facet visibilities ``V`` of every visible pair are geometric and are computed once when the state is built; the temperatures they weight are those of each time step. For a flat roughness model every sub-facet sees every neighbour with the inclination of the facet, and the sum reduces to the smooth-surface flux of the facet. The global-level fluxes of ``i`` are not affected: they remain the smooth-surface baseline.
+
 ## Direction-Dependent Radiance of a Rough Facet
 
 A facet with a roughness model does not radiate as a Lambertian surface: the sunlit wall of a crater is hotter than the shadowed one, and which wall an observer sees depends on the viewing direction. This is thermal-infrared *beaming*. The radiance of such a facet towards an observer direction ``\hat{\mathbf d}`` is evaluated as a post-processing step from the recorded sub-facet temperatures ([`roughness_radiance`](@ref), [`directional_radiance`](@ref)):

--- a/src/directional_radiance.jl
+++ b/src/directional_radiance.jl
@@ -16,7 +16,7 @@ _lambert_radiance(T, λ::Real)   = blackbody_radiance(λ, T) / π
 _brightness_temperature(L, ::Nothing) = (π * L / σ_SB)^(1/4)
 function _brightness_temperature(L, λ::Real)
     # π L = 2 h c² / λ⁵ / expm1(h c / (λ k T))  ⇒  T = h c / (λ k log1p(2 h c² / (λ⁵ π L)))
-    L <= 0 && return L == 0 ? 0.0 : NaN
+    L ≤ 0 && return L == 0 ? 0.0 : NaN
     h * c₀ / (λ * k_B * log1p(2 * h * c₀^2 / (λ^5 * π * L)))
 end
 
@@ -69,19 +69,19 @@ function roughness_radiance(
     shape::ShapeModel, i::Integer, T_sub::AbstractVector{<:Real}, ε::Real,
     d̂::StaticVector{3}; λ::Union{Nothing, Real} = nothing,
 )
-    model = get_roughness_model(shape, i)::ShapeModel
-    length(T_sub) == length(model.faces) || throw(ArgumentError(
-        "T_sub has $(length(T_sub)) entries but the roughness model of facet $i has $(length(model.faces)) facets"
+    patch = get_roughness_model(shape, i)::ShapeModel
+    length(T_sub) == length(patch.faces) || throw(ArgumentError(
+        "T_sub has $(length(T_sub)) entries but the roughness model of facet $i has $(length(patch.faces)) facets"
     ))
     d̂_local = transform_physical_vector_global_to_local(shape, i, normalize(d̂))
     cosθ_view = d̂_local[3]
-    cosθ_view <= 0 && return NaN
+    cosθ_view ≤ 0 && return NaN
 
-    _prepare_self_shadowing!(model)
-    visible = Vector{Bool}(undef, length(model.faces))
-    update_illumination!(visible, model, d̂_local; with_self_shadowing=true)
+    _prepare_self_shadowing!(patch)
+    visible = Vector{Bool}(undef, length(patch.faces))
+    update_illumination!(visible, patch, d̂_local; with_self_shadowing=true)
 
-    return _directional_emission(model, visible, d̂_local, n -> ε * _lambert_radiance(T_sub[n], λ))
+    return _directional_emission(patch, visible, d̂_local, n -> ε * _lambert_radiance(T_sub[n], λ))
 end
 
 

--- a/src/directional_radiance.jl
+++ b/src/directional_radiance.jl
@@ -81,14 +81,7 @@ function roughness_radiance(
     visible = Vector{Bool}(undef, length(model.faces))
     update_illumination!(visible, model, d̂_local; with_self_shadowing=true)
 
-    emitted = 0.0
-    for j in eachindex(model.faces)
-        visible[j] || continue
-        cosθ_j = model.face_normals[j] ⋅ d̂_local
-        cosθ_j <= 0 && continue
-        emitted += cosθ_j * model.face_areas[j] * ε * _lambert_radiance(T_sub[j], λ)
-    end
-    return emitted / (projected_area(model) * cosθ_view)
+    return _directional_emission(model, visible, d̂_local, n -> ε * _lambert_radiance(T_sub[n], λ))
 end
 
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -533,7 +533,7 @@ function _add_external!(state::SingleAsteroidThermoPhysicalState, k::Integer, i:
         else
             rs_j    = state.roughness_states[k_j]
             patch_j = rs_j.problem.shape
-            visible_sub_faces_j = state.roughness_neighbours[k_j].visible_sub_faces[neighbours.position_in_neighbour[p]]
+            visible_sub_faces_j = state.roughness_neighbours[k_j].visible_sub_faces[neighbours.index_in_neighbour[p]]
             d̂ⱼᵢ     = transform_physical_vector_global_to_local(shape, j, -d̂ᵢⱼ)
             tp_j    = rs_j.problem.thermo_params
             Eⱼ = kind === :rad ?

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -415,38 +415,136 @@ function update_flux_scat_single!(state::SingleAsteroidThermoPhysicalState)
     _update_flux_scat_single!(state, state.problem.shape)
 
     # Sub-faces of every roughness model (empty loop for a smooth surface): scattering between
-    # the sub-faces, plus the scattered light the parent face receives from the other faces,
-    # distributed over the sub-faces by their sky view factor (see `_add_external_irradiance!`).
-    # The global level must be updated first: the external term reads `state.flux_scat`.
+    # the sub-faces, plus the sunlight reflected towards them by the other global faces — from
+    # the sub-faces of those faces' own roughness models, direction by direction (see
+    # `_add_external_scattering!`). Only with self-heating, which is what the external term is.
     for (i, k) in enumerate(state.face_roughness_indices)
         k == 0 && continue
         rs = state.roughness_states[k]
         _update_flux_scat_single!(rs, rs.problem.shape)
-        _add_external_irradiance!(rs.flux_scat, rs.problem.shape, state.flux_scat[i])
+        state.problem.with_self_heating && _add_external_scattering!(state, k, i)
     end
 end
 
 
 """
-    _add_external_irradiance!(flux_sub, shape::ShapeModel, flux_parent)
+    _directional_emission(model::ShapeModel, visible, d̂_local, emission) -> E
 
-Add to the sub-face fluxes `flux_sub` of a roughness model `shape` the flux `flux_parent` that
-its parent global face receives from the other global faces.
+Emission of a roughness model `model` towards the direction `d̂_local` (unit vector in the local
+frame of the model), per unit area of the model's reference plane projected onto that direction:
+```
+E(d̂) = Σₙ Vₙ (n̂ₙ ⋅ d̂)⁺ Eₙ aₙ / (A_proj cos θ)
+```
+where `visible[n]` (`Vₙ`) tells whether sub-face `n` is seen from `d̂`, `emission(n)` (`Eₙ`)
+is the quantity emitted by sub-face `n` per unit area — `ε σ T⁴` for thermal emission,
+`R_vis F_sun` for reflected sunlight, a radiance for `roughness_radiance` — and `cos θ` is the
+z component of `d̂_local`. For a uniform, unshadowed model this reduces to `E = Eₙ`: the
+representative patch radiates like a smooth Lambertian face. Sub-faces facing away from `d̂`
+do not contribute.
 
-The parent flux is taken as isotropic over the parent's sky hemisphere, so sub-face `j`
-receives it in proportion to its sky view factor `1 − Σₖ fⱼₖ` — the part of the hemisphere not
-covered by the other sub-faces. A sub-face on the floor of a deep crater therefore receives
-less than one on the rim, and a flat roughness model receives exactly the parent flux. On a
-convex body the parent flux is zero and nothing is added.
-
-This is the isotropic limit of a directional treatment in which each neighbouring global
-face radiates with its own rough-surface beaming; it is the level implemented for now.
+The caller guarantees `cos θ > 0`.
 """
-function _add_external_irradiance!(flux_sub::AbstractVector, shape::ShapeModel, flux_parent::Real)
-    iszero(flux_parent) && return
-    graph = shape.face_visibility_graph
-    for j in eachindex(shape.faces)
-        flux_sub[j] += _sky_view_factor(graph, j) * flux_parent
+function _directional_emission(model::ShapeModel, visible, d̂_local::StaticVector{3}, emission)
+    cosθ  = d̂_local[3]
+    total = 0.0
+    for n in eachindex(model.faces)
+        visible[n] || continue
+        cosθ_n = model.face_normals[n] ⋅ d̂_local
+        cosθ_n <= 0 && continue
+        total += cosθ_n * model.face_areas[n] * emission(n)
+    end
+    return total / (projected_area(model) * cosθ)
+end
+
+
+# Add to the sub-face fluxes `flux_sub` of `model` the irradiance `F` that the parent face
+# receives from the direction `d̂_local` (local frame): a distant source of intensity `F / cos θ`
+# lights the sub-faces it can see, each by its own inclination — the same rule as for the
+# sunlight. The power received, Σₘ Fₘ aₘ, equals F A_proj up to the shadowing discretisation
+# of the sub-faces (seen or not from the ray through their centre): on a height field every
+# ray through the reference plane meets a sub-face, the walls shading the floor.
+function _distribute_directional!(flux_sub::AbstractVector, model::ShapeModel, visible, d̂_local::StaticVector{3}, F::Real)
+    cosθ = d̂_local[3]
+    (F <= 0 || cosθ <= 0) && return
+    intensity = F / cosθ
+    for m in eachindex(model.faces)
+        visible[m] || continue
+        cosθ_m = model.face_normals[m] ⋅ d̂_local
+        cosθ_m > 0 && (flux_sub[m] += intensity * cosθ_m)
+    end
+end
+
+
+"""
+    _add_external_radiation!(state, k, i)
+    _add_external_scattering!(state, k, i)
+
+Add to the sub-faces of the roughness model on global face `i` (sub-state `k`) the thermal
+radiation, respectively the reflected sunlight, that they receive from the other global faces.
+
+For every face `j` visible from `i` (view factor `f_ij`, direction `d̂_ij` from the face
+visibility graph):
+
+1. **Emitter**: the emission of `j` towards `i`. If `j` carries a roughness model, it is the
+   directional emission of that model (`_directional_emission`) — the hot sunlit wall of a
+   crater that faces `i` radiates more towards `i` than a smooth face would (thermal-infrared
+   beaming), a shaded wall less. The sub-faces of `j` seen from `i` come from the mask that `j`
+   precomputed towards `i` (`RoughnessNeighbours`). If `j` is smooth, it radiates as a Lambertian
+   face, `ε σ T_j⁴` or `R_vis F_sun,j`.
+2. **Far-field**: the irradiance reaching face `i` is `F_ij = E_j(d̂_ji) f_ij`, the same form as
+   the smooth-face term `ε σ T_j⁴ f_ij` — the view factor already carries the geometry of the
+   pair, and both faces are taken as small compared to their distance, as the view factor does.
+3. **Receiver**: `F_ij` is distributed over the sub-faces of `i` that see `j`
+   (`_distribute_directional!`), so the wall facing `j` is heated and the wall behind it is not.
+
+Thermal emission uses the sub-face temperatures of the previous time step and reflected sunlight
+uses the direct solar flux only (single scattering, as on the global level), so the result does
+not depend on the order in which the roughness models are updated. The global-level fluxes of
+face `i` are not touched: they remain the smooth-surface baseline.
+"""
+function _add_external_radiation!(state::SingleAsteroidThermoPhysicalState, k::Integer, i::Integer)
+    _add_external!(state, k, i, :rad)
+end
+
+function _add_external_scattering!(state::SingleAsteroidThermoPhysicalState, k::Integer, i::Integer)
+    _add_external!(state, k, i, :scat)
+end
+
+function _add_external!(state::SingleAsteroidThermoPhysicalState, k::Integer, i::Integer, kind::Symbol)
+    shape      = state.problem.shape
+    graph      = shape.face_visibility_graph
+    rs         = state.roughness_states[k]
+    neighbours = state.roughness_neighbours[k]
+    model      = rs.problem.shape
+    flux_sub   = kind === :rad ? rs.flux_rad : rs.flux_scat
+
+    visible_indices = get_visible_face_indices(graph, i)
+    view_factors    = get_view_factors(graph, i)
+    directions      = get_visible_face_directions(graph, i)
+
+    for (p, (j, fᵢⱼ, d̂ᵢⱼ)) in enumerate(zip(visible_indices, view_factors, directions))
+        k_j = state.face_roughness_indices[j]
+
+        # Emitter: j towards i
+        if k_j == 0
+            Eⱼ = kind === :rad ?
+                state.problem.thermo_params.emissivity[j] * σ_SB * state.temperature[begin, j]^4 :
+                state.problem.thermo_params.reflectance_vis[j] * state.flux_sun[j]
+        else
+            rs_j    = state.roughness_states[k_j]
+            model_j = rs_j.problem.shape
+            seen_j  = state.roughness_neighbours[k_j].visible[neighbours.position_in_neighbour[p]]
+            d̂ⱼᵢ     = transform_physical_vector_global_to_local(shape, j, -d̂ᵢⱼ)
+            tp_j    = rs_j.problem.thermo_params
+            Eⱼ = kind === :rad ?
+                _directional_emission(model_j, seen_j, d̂ⱼᵢ, n -> tp_j.emissivity[n] * σ_SB * rs_j.temperature[begin, n]^4) :
+                _directional_emission(model_j, seen_j, d̂ⱼᵢ, n -> tp_j.reflectance_vis[n] * rs_j.flux_sun[n])
+        end
+
+        # Far-field: irradiance on face i, then distributed over the sub-faces that see j
+        Fᵢⱼ = Eⱼ * fᵢⱼ
+        d̂ᵢⱼ_local = transform_physical_vector_global_to_local(shape, i, d̂ᵢⱼ)
+        _distribute_directional!(flux_sub, model, neighbours.visible[p], d̂ᵢⱼ_local, Fᵢⱼ)
     end
 end
 
@@ -526,15 +624,13 @@ function update_flux_rad_single!(state::SingleAsteroidThermoPhysicalState)
 
     # Sub-faces of every roughness model (empty loop for a smooth surface): radiative exchange
     # between the sub-faces from their surface temperatures, plus the thermal radiation the
-    # parent face receives from the other faces, distributed over the sub-faces by their sky
-    # view factor. The global level must be updated first: the external term reads
-    # `state.flux_rad`, and it carries the neighbours' smooth-surface temperatures rather than
-    # their rough-surface emission.
+    # other global faces send towards them — from the sub-faces of those faces' own roughness
+    # models, direction by direction (see `_add_external_radiation!`). Only with self-heating.
     for (i, k) in enumerate(state.face_roughness_indices)
         k == 0 && continue
         rs = state.roughness_states[k]
         _update_flux_rad_single!(rs, rs.problem.shape)
-        _add_external_irradiance!(rs.flux_rad, rs.problem.shape, state.flux_rad[i])
+        state.problem.with_self_heating && _add_external_radiation!(state, k, i)
     end
 end
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -428,48 +428,48 @@ end
 
 
 """
-    _directional_emission(model::ShapeModel, visible, d̂_local, emission) -> E
+    _directional_emission(patch::ShapeModel, visible, d̂_local, emission) -> E
 
-Emission of a roughness model `model` towards the direction `d̂_local` (unit vector in the local
-frame of the model), per unit area of the model's reference plane projected onto that direction:
+Emission of a roughness model `patch` towards the direction `d̂_local` (unit vector in the local
+frame of the patch), per unit area of the patch's reference plane projected onto that direction:
 ```
 E(d̂) = Σₙ Vₙ (n̂ₙ ⋅ d̂)⁺ Eₙ aₙ / (A_proj cos θ)
 ```
 where `visible[n]` (`Vₙ`) tells whether sub-face `n` is seen from `d̂`, `emission(n)` (`Eₙ`)
 is the quantity emitted by sub-face `n` per unit area — `ε σ T⁴` for thermal emission,
 `R_vis F_sun` for reflected sunlight, a radiance for `roughness_radiance` — and `cos θ` is the
-z component of `d̂_local`. For a uniform, unshadowed model this reduces to `E = Eₙ`: the
+z component of `d̂_local`. For a uniform, unshadowed patch this reduces to `E = Eₙ`: the
 representative patch radiates like a smooth Lambertian face. Sub-faces facing away from `d̂`
 do not contribute.
 
 The caller guarantees `cos θ > 0`.
 """
-function _directional_emission(model::ShapeModel, visible, d̂_local::StaticVector{3}, emission)
+function _directional_emission(patch::ShapeModel, visible, d̂_local::StaticVector{3}, emission)
     cosθ  = d̂_local[3]
     total = 0.0
-    for n in eachindex(model.faces)
+    for n in eachindex(patch.faces)
         visible[n] || continue
-        cosθ_n = model.face_normals[n] ⋅ d̂_local
-        cosθ_n <= 0 && continue
-        total += cosθ_n * model.face_areas[n] * emission(n)
+        cosθ_n = patch.face_normals[n] ⋅ d̂_local
+        cosθ_n ≤ 0 && continue
+        total += cosθ_n * patch.face_areas[n] * emission(n)
     end
-    return total / (projected_area(model) * cosθ)
+    return total / (projected_area(patch) * cosθ)
 end
 
 
-# Add to the sub-face fluxes `flux_sub` of `model` the irradiance `F` that the parent face
+# Add to the sub-face fluxes `flux_sub` of `patch` the irradiance `F` that the parent face
 # receives from the direction `d̂_local` (local frame): a distant source of intensity `F / cos θ`
 # lights the sub-faces it can see, each by its own inclination — the same rule as for the
 # sunlight. The power received, Σₘ Fₘ aₘ, equals F A_proj up to the shadowing discretisation
 # of the sub-faces (seen or not from the ray through their centre): on a height field every
 # ray through the reference plane meets a sub-face, the walls shading the floor.
-function _distribute_directional!(flux_sub::AbstractVector, model::ShapeModel, visible, d̂_local::StaticVector{3}, F::Real)
+function _distribute_directional!(flux_sub::AbstractVector, patch::ShapeModel, visible, d̂_local::StaticVector{3}, F::Real)
     cosθ = d̂_local[3]
-    (F <= 0 || cosθ <= 0) && return
+    (F ≤ 0 || cosθ ≤ 0) && return
     intensity = F / cosθ
-    for m in eachindex(model.faces)
+    for m in eachindex(patch.faces)
         visible[m] || continue
-        cosθ_m = model.face_normals[m] ⋅ d̂_local
+        cosθ_m = patch.face_normals[m] ⋅ d̂_local
         cosθ_m > 0 && (flux_sub[m] += intensity * cosθ_m)
     end
 end
@@ -515,7 +515,7 @@ function _add_external!(state::SingleAsteroidThermoPhysicalState, k::Integer, i:
     graph      = shape.face_visibility_graph
     rs         = state.roughness_states[k]
     neighbours = state.roughness_neighbours[k]
-    model      = rs.problem.shape
+    patch      = rs.problem.shape
     flux_sub   = kind === :rad ? rs.flux_rad : rs.flux_scat
 
     visible_indices = get_visible_face_indices(graph, i)
@@ -532,19 +532,19 @@ function _add_external!(state::SingleAsteroidThermoPhysicalState, k::Integer, i:
                 state.problem.thermo_params.reflectance_vis[j] * state.flux_sun[j]
         else
             rs_j    = state.roughness_states[k_j]
-            model_j = rs_j.problem.shape
-            seen_j  = state.roughness_neighbours[k_j].visible[neighbours.position_in_neighbour[p]]
+            patch_j = rs_j.problem.shape
+            visible_sub_faces_j = state.roughness_neighbours[k_j].visible_sub_faces[neighbours.position_in_neighbour[p]]
             d̂ⱼᵢ     = transform_physical_vector_global_to_local(shape, j, -d̂ᵢⱼ)
             tp_j    = rs_j.problem.thermo_params
             Eⱼ = kind === :rad ?
-                _directional_emission(model_j, seen_j, d̂ⱼᵢ, n -> tp_j.emissivity[n] * σ_SB * rs_j.temperature[begin, n]^4) :
-                _directional_emission(model_j, seen_j, d̂ⱼᵢ, n -> tp_j.reflectance_vis[n] * rs_j.flux_sun[n])
+                _directional_emission(patch_j, visible_sub_faces_j, d̂ⱼᵢ, n -> tp_j.emissivity[n] * σ_SB * rs_j.temperature[begin, n]^4) :
+                _directional_emission(patch_j, visible_sub_faces_j, d̂ⱼᵢ, n -> tp_j.reflectance_vis[n] * rs_j.flux_sun[n])
         end
 
         # Far-field: irradiance on face i, then distributed over the sub-faces that see j
         Fᵢⱼ = Eⱼ * fᵢⱼ
         d̂ᵢⱼ_local = transform_physical_vector_global_to_local(shape, i, d̂ᵢⱼ)
-        _distribute_directional!(flux_sub, model, neighbours.visible[p], d̂ᵢⱼ_local, Fᵢⱼ)
+        _distribute_directional!(flux_sub, patch, neighbours.visible_sub_faces[p], d̂ᵢⱼ_local, Fᵢⱼ)
     end
 end
 

--- a/src/energy_flux.jl
+++ b/src/energy_flux.jl
@@ -463,7 +463,7 @@ end
 # sunlight. The power received, Σₘ Fₘ aₘ, equals F A_proj up to the shadowing discretisation
 # of the sub-faces (seen or not from the ray through their centre): on a height field every
 # ray through the reference plane meets a sub-face, the walls shading the floor.
-function _distribute_directional!(flux_sub::AbstractVector, patch::ShapeModel, visible, d̂_local::StaticVector{3}, F::Real)
+function _add_directional_irradiance!(flux_sub::AbstractVector, patch::ShapeModel, visible, d̂_local::StaticVector{3}, F::Real)
     cosθ = d̂_local[3]
     (F ≤ 0 || cosθ ≤ 0) && return
     intensity = F / cosθ
@@ -495,7 +495,7 @@ visibility graph):
    the smooth-face term `ε σ T_j⁴ f_ij` — the view factor already carries the geometry of the
    pair, and both faces are taken as small compared to their distance, as the view factor does.
 3. **Receiver**: `F_ij` is distributed over the sub-faces of `i` that see `j`
-   (`_distribute_directional!`), so the wall facing `j` is heated and the wall behind it is not.
+   (`_add_directional_irradiance!`), so the wall facing `j` is heated and the wall behind it is not.
 
 Thermal emission uses the sub-face temperatures of the previous time step and reflected sunlight
 uses the direct solar flux only (single scattering, as on the global level), so the result does
@@ -544,7 +544,7 @@ function _add_external!(state::SingleAsteroidThermoPhysicalState, k::Integer, i:
         # Far-field: irradiance on face i, then distributed over the sub-faces that see j
         Fᵢⱼ = Eⱼ * fᵢⱼ
         d̂ᵢⱼ_local = transform_physical_vector_global_to_local(shape, i, d̂ᵢⱼ)
-        _distribute_directional!(flux_sub, patch, neighbours.visible_sub_faces[p], d̂ᵢⱼ_local, Fᵢⱼ)
+        _add_directional_irradiance!(flux_sub, patch, neighbours.visible_sub_faces[p], d̂ᵢⱼ_local, Fᵢⱼ)
     end
 end
 

--- a/src/non_grav.jl
+++ b/src/non_grav.jl
@@ -157,12 +157,12 @@ function update_thermal_force!(state::SingleAsteroidThermoPhysicalState)
     for (i, k) in enumerate(state.face_roughness_indices)
         k == 0 && continue
         rs = state.roughness_states[k]
-        roughness_shape = rs.problem.shape
+        patch = rs.problem.shape
         update_thermal_force!(rs)  # includes the re-absorption inside the roughness model
 
         # Representative patch: count the model-unit forces for the parent's area. The
         # rotation is linear, so the sub-face forces are summed first and rotated once.
-        patches_per_face = shape.face_areas[i] / projected_area(roughness_shape)
+        patches_per_face = shape.face_areas[i] / projected_area(patch)
         f_sum = sum(rs.face_forces)
         state.face_forces[i] = patches_per_face * transform_physical_vector_local_to_global(shape, i, f_sum)
 
@@ -171,9 +171,9 @@ function update_thermal_force!(state::SingleAsteroidThermoPhysicalState)
         # escaping the model, P_sky = (A_i / A_proj) Σⱼ E_j a_j f_sky,j, contributes
         # P_sky / c × Σₖ f_ik d̂_ik.
         if with_self_heating
-            graph_sub = roughness_shape.face_visibility_graph
-            P_sky = patches_per_face * sum(eachindex(roughness_shape.faces)) do j
-                _emittance(rs, j) * roughness_shape.face_areas[j] * _sky_view_factor(graph_sub, j)
+            graph_sub = patch.face_visibility_graph
+            P_sky = patches_per_face * sum(eachindex(patch.faces)) do j
+                _emittance(rs, j) * patch.face_areas[j] * _sky_view_factor(graph_sub, j)
             end
             view_factors = get_view_factors(shape.face_visibility_graph, i)
             directions   = get_visible_face_directions(shape.face_visibility_graph, i)

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -77,7 +77,9 @@ function _build_single_state(
         # The exchange of radiation between roughness models needs, for every pair of visible
         # faces, the sub-faces that each model exposes towards the other. Only with self-heating.
         if problem.with_self_heating
-            roughness_neighbours = _build_roughness_neighbours(shape, face_roughness_indices)
+            _log_elapsed("Building sub-facet visibility masks for the roughness models") do
+                roughness_neighbours = _build_roughness_neighbours(shape, face_roughness_indices)
+            end
         end
     end
 

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -47,7 +47,7 @@ function _build_single_state(
 
         # Build an independent sub-face state for each face with roughness
         roughness_states = map(findall(!=(0), face_roughness_indices)) do i
-            roughness_shape = get_roughness_model(shape, i)::ShapeModel
+            patch = get_roughness_model(shape, i)::ShapeModel
             tp_sub = ThermoParams(
                 [problem.thermo_params.conductivity[i]],
                 [problem.thermo_params.density[i]],
@@ -65,7 +65,7 @@ function _build_single_state(
             # Roughness models are smooth `ShapeModel`s (enforced by `add_roughness_models!`),
             # so the recursion terminates here.
             mini_prob = SingleAsteroidThermoPhysicalProblem(
-                roughness_shape, tp_sub, problem.grid_params;
+                patch, tp_sub, problem.grid_params;
                 with_self_shadowing = true,
                 with_self_heating   = true,
                 upper_boundary_condition = problem.upper_boundary_condition,
@@ -103,24 +103,24 @@ end
 
 # For every face with a roughness model, the visibility of its sub-faces from the direction of
 # each neighbouring global face, and the position of the face in that neighbour's own list.
-# The direction `d̂_ij` of the visibility graph is rotated into the local frame of the model and
+# The direction `d̂_ij` of the visibility graph is rotated into the local frame of the patch and
 # handed to `update_illumination!` in place of the Sun: illumination from a direction is the
 # same test as being seen from it. The masks are geometry only; the temperatures they weight are
 # supplied at every step.
 function _build_roughness_neighbours(shape::ShapeModel, face_roughness_indices::Vector{Int})
     graph = shape.face_visibility_graph
     map(findall(!=(0), face_roughness_indices)) do i
-        model      = get_roughness_model(shape, i)::ShapeModel
+        patch      = get_roughness_model(shape, i)::ShapeModel
         neighbours = get_visible_face_indices(graph, i)
         directions = get_visible_face_directions(graph, i)
-        visible    = Vector{BitVector}(undef, length(neighbours))
+        visible_sub_faces = Vector{BitVector}(undef, length(neighbours))
         position   = zeros(Int, length(neighbours))
-        seen       = Vector{Bool}(undef, length(model.faces))
+        seen       = Vector{Bool}(undef, length(patch.faces))
 
         for (p, (j, d̂_ij)) in enumerate(zip(neighbours, directions))
             d̂_local = transform_physical_vector_global_to_local(shape, i, d̂_ij)
-            update_illumination!(seen, model, d̂_local; with_self_shadowing=true)
-            visible[p] = BitVector(seen)
+            update_illumination!(seen, patch, d̂_local; with_self_shadowing=true)
+            visible_sub_faces[p] = BitVector(seen)
 
             if face_roughness_indices[j] != 0
                 q = findfirst(==(i), get_visible_face_indices(graph, j))
@@ -131,7 +131,7 @@ function _build_roughness_neighbours(shape::ShapeModel, face_roughness_indices::
             end
         end
 
-        RoughnessNeighbours(visible, position)
+        RoughnessNeighbours(visible_sub_faces, position)
     end
 end
 

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -32,6 +32,7 @@ function _build_single_state(
 
     face_roughness_indices = Int[]
     roughness_states       = SingleAsteroidThermoPhysicalState{typeof(problem), typeof(cache)}[]
+    roughness_neighbours   = RoughnessNeighbours[]
 
     if has_roughness(shape)
         # Map each face to an independent roughness state index (0 = no roughness)
@@ -72,6 +73,12 @@ function _build_single_state(
             )
             _build_single_state(mini_prob, algorithm)
         end
+
+        # The exchange of radiation between roughness models needs, for every pair of visible
+        # faces, the sub-faces that each model exposes towards the other. Only with self-heating.
+        if problem.with_self_heating
+            roughness_neighbours = _build_roughness_neighbours(shape, face_roughness_indices)
+        end
     end
 
     SingleAsteroidThermoPhysicalState(
@@ -87,7 +94,43 @@ function _build_single_state(
         zero(MVector{3, Float64}),
         face_roughness_indices,
         roughness_states,
+        roughness_neighbours,
     )
+end
+
+
+# For every face with a roughness model, the visibility of its sub-faces from the direction of
+# each neighbouring global face, and the position of the face in that neighbour's own list.
+# The direction `d̂_ij` of the visibility graph is rotated into the local frame of the model and
+# handed to `update_illumination!` in place of the Sun: illumination from a direction is the
+# same test as being seen from it. The masks are geometry only; the temperatures they weight are
+# supplied at every step.
+function _build_roughness_neighbours(shape::ShapeModel, face_roughness_indices::Vector{Int})
+    graph = shape.face_visibility_graph
+    map(findall(!=(0), face_roughness_indices)) do i
+        model      = get_roughness_model(shape, i)::ShapeModel
+        neighbours = get_visible_face_indices(graph, i)
+        directions = get_visible_face_directions(graph, i)
+        visible    = Vector{BitVector}(undef, length(neighbours))
+        position   = zeros(Int, length(neighbours))
+        seen       = Vector{Bool}(undef, length(model.faces))
+
+        for (p, (j, d̂_ij)) in enumerate(zip(neighbours, directions))
+            d̂_local = transform_physical_vector_global_to_local(shape, i, d̂_ij)
+            update_illumination!(seen, model, d̂_local; with_self_shadowing=true)
+            visible[p] = BitVector(seen)
+
+            if face_roughness_indices[j] != 0
+                q = findfirst(==(i), get_visible_face_indices(graph, j))
+                isnothing(q) && throw(ArgumentError(
+                    "face_visibility_graph is not symmetric: face $i sees face $j but not the reverse"
+                ))
+                position[p] = q
+            end
+        end
+
+        RoughnessNeighbours(visible, position)
+    end
 end
 
 

--- a/src/tpm_solve.jl
+++ b/src/tpm_solve.jl
@@ -102,7 +102,7 @@ end
 
 
 # For every face with a roughness model, the visibility of its sub-faces from the direction of
-# each neighbouring global face, and the position of the face in that neighbour's own list.
+# each neighbouring global face, and the index of the face in that neighbour's own list.
 # The direction `d̂_ij` of the visibility graph is rotated into the local frame of the patch and
 # handed to `update_illumination!` in place of the Sun: illumination from a direction is the
 # same test as being seen from it. The masks are geometry only; the temperatures they weight are
@@ -114,7 +114,7 @@ function _build_roughness_neighbours(shape::ShapeModel, face_roughness_indices::
         neighbours = get_visible_face_indices(graph, i)
         directions = get_visible_face_directions(graph, i)
         visible_sub_faces = Vector{BitVector}(undef, length(neighbours))
-        position   = zeros(Int, length(neighbours))
+        index_in_neighbour = zeros(Int, length(neighbours))
         seen       = Vector{Bool}(undef, length(patch.faces))
 
         for (p, (j, d̂_ij)) in enumerate(zip(neighbours, directions))
@@ -127,11 +127,11 @@ function _build_roughness_neighbours(shape::ShapeModel, face_roughness_indices::
                 isnothing(q) && throw(ArgumentError(
                     "face_visibility_graph is not symmetric: face $i sees face $j but not the reverse"
                 ))
-                position[p] = q
+                index_in_neighbour[p] = q
             end
         end
 
-        RoughnessNeighbours(visible_sub_faces, position)
+        RoughnessNeighbours(visible_sub_faces, index_in_neighbour)
     end
 end
 

--- a/src/tpm_state.jl
+++ b/src/tpm_state.jl
@@ -24,13 +24,13 @@ state construction, when `with_self_heating` is enabled.
 - `visible_sub_faces`     : `visible_sub_faces[p][m]` is `true` when sub-face `m` is seen from the direction
                             of the `p`-th visible global face (in the local frame of the model,
                             including self-shadowing by the model's own topography)
-- `position_in_neighbour` : Position of this face in the list of the `p`-th visible face, so that
+- `index_in_neighbour`    : Index of this face in the list of the `p`-th visible face, so that
                             the neighbour's mask towards this face can be read directly; `0` when
                             the neighbour has no roughness model
 """
 struct RoughnessNeighbours
     visible_sub_faces     ::Vector{BitVector}
-    position_in_neighbour ::Vector{Int}
+    index_in_neighbour    ::Vector{Int}
 end
 
 

--- a/src/tpm_state.jl
+++ b/src/tpm_state.jl
@@ -12,6 +12,29 @@ abstract type AbstractAsteroidThermoPhysicalState end
 
 
 """
+    struct RoughnessNeighbours
+
+For one global face that carries a roughness model: which of its sub-faces are seen from the
+direction of each neighbouring global face, in the order of the face's list in the face
+visibility graph. This is the geometric part of the exchange of radiation between roughness
+models (see `update_flux_rad_single!`); it does not change during a run and is built once, at
+state construction, when `with_self_heating` is enabled.
+
+# Fields
+- `visible`               : `visible[p][m]` is `true` when sub-face `m` is seen from the direction
+                            of the `p`-th visible global face (in the local frame of the model,
+                            including self-shadowing by the model's own topography)
+- `position_in_neighbour` : Position of this face in the list of the `p`-th visible face, so that
+                            the neighbour's mask towards this face can be read directly; `0` when
+                            the neighbour has no roughness model
+"""
+struct RoughnessNeighbours
+    visible               ::Vector{BitVector}
+    position_in_neighbour ::Vector{Int}
+end
+
+
+"""
     struct SingleAsteroidThermoPhysicalState <: AbstractAsteroidThermoPhysicalState
 
 Internal simulation state for a single-asteroid thermophysical model.
@@ -39,6 +62,10 @@ accessed via the `problem` field to avoid duplication.
                              empty when the shape has no roughness. Each sub-state is itself a
                              `SingleAsteroidThermoPhysicalState` with empty roughness (the
                              roughness models are smooth `ShapeModel`s)
+- `roughness_neighbours`   : Per roughness-carrying face (same order as `roughness_states`),
+                             the visibility of its sub-faces from the direction of each
+                             neighbouring global face (`RoughnessNeighbours`). Built only when
+                             `with_self_heating` is enabled; empty otherwise
 
 # Notes
 When the shape carries surface roughness (`has_roughness(problem.shape)`), the fields above
@@ -62,6 +89,7 @@ struct SingleAsteroidThermoPhysicalState{
     torque            ::MVector{3, Float64}
     face_roughness_indices ::Vector{Int}
     roughness_states       ::Vector{SingleAsteroidThermoPhysicalState{Pr, HCC}}
+    roughness_neighbours   ::Vector{RoughnessNeighbours}
 end
 
 

--- a/src/tpm_state.jl
+++ b/src/tpm_state.jl
@@ -21,7 +21,7 @@ models (see `update_flux_rad_single!`); it does not change during a run and is b
 state construction, when `with_self_heating` is enabled.
 
 # Fields
-- `visible`               : `visible[p][m]` is `true` when sub-face `m` is seen from the direction
+- `visible_sub_faces`     : `visible_sub_faces[p][m]` is `true` when sub-face `m` is seen from the direction
                             of the `p`-th visible global face (in the local frame of the model,
                             including self-shadowing by the model's own topography)
 - `position_in_neighbour` : Position of this face in the list of the `p`-th visible face, so that
@@ -29,7 +29,7 @@ state construction, when `with_self_heating` is enabled.
                             the neighbour has no roughness model
 """
 struct RoughnessNeighbours
-    visible               ::Vector{BitVector}
+    visible_sub_faces     ::Vector{BitVector}
     position_in_neighbour ::Vector{Int}
 end
 

--- a/test/test_roughness_solve.jl
+++ b/test/test_roughness_solve.jl
@@ -128,14 +128,21 @@ End-to-end tests of `solve` on a `ShapeModel` with surface roughness:
         n_cycle = 10
         times, ephem = make_ephem(n_cycle; with_rotation=false)
         output = SingleAsteroidOutputSpec(times[end:end]; save_surface_temperature = true)
+        last_cycle = length(times)-n_step_cycle+1:length(times)
 
+        # Convex global shape: no exchange between global faces
         shape_hier = load_shape_obj(path_obj)
         add_roughness_models!(shape_hier, roughness_model)
-
         sol = solve(make_problem(shape_hier; with_self_heating=true), CrankNicolson();
             ephem, output, initial_temperature=200.0)
+        ratio = sum(sol.emitted_power[last_cycle]) / sum(sol.absorbed_power[last_cycle])
+        @test abs(ratio - 1) < 0.05
 
-        last_cycle = length(times)-n_step_cycle+1:length(times)
+        # Concave global shape: the roughness models exchange radiation with each other
+        shape_concave = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
+        add_roughness_models!(shape_concave, roughness_model)
+        sol = solve(make_problem(shape_concave; with_self_heating=true), CrankNicolson();
+            ephem, output, initial_temperature=200.0)
         ratio = sum(sol.emitted_power[last_cycle]) / sum(sol.absorbed_power[last_cycle])
         @test abs(ratio - 1) < 0.05
     end

--- a/test/test_roughness_state.jl
+++ b/test/test_roughness_state.jl
@@ -955,6 +955,12 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
         state_hier  = AsteroidThermoPhysicalModels._build_single_state(problem_hier,  CrankNicolson())
         AsteroidThermoPhysicalModels.init_temperature!(state_plain, 250.0)
         AsteroidThermoPhysicalModels.init_temperature!(state_hier,  250.0)
+        # A uniform temperature gives the crater exactly the recoil of the flat face: the direct
+        # recoils sum to -2/3 E A_proj ẑ and the re-absorption recoils cancel pairwise by
+        # reciprocity (a_j f_jk = a_k f_kj, d̂_jk = -d̂_kj). Make the sub-faces differ so that
+        # the crater really has a force of its own.
+        rs = state_hier.roughness_states[1]
+        rs.temperature[begin, :] .= range(240.0, 260.0; length=length(rs.problem.shape.faces))
 
         r☉ = SVector(0.3, -0.2, 0.9) * AsteroidThermoPhysicalModels.au2m
         update_fluxes_and_force!(state_plain, r☉)
@@ -962,6 +968,7 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
 
         @test state_hier.face_forces[2:end] == state_plain.face_forces[2:end]
         @test state_hier.face_forces[1]     != state_plain.face_forces[1]
+        @test !isapprox(state_hier.face_forces[1], state_plain.face_forces[1]; rtol=1e-6)
         @test state_hier.force ≈ sum(state_hier.face_forces)
     end
 

--- a/test/test_roughness_state.jl
+++ b/test/test_roughness_state.jl
@@ -10,8 +10,9 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
   standalone roughness model, and a near-flat roughness model reproducing the parent face
 - update_flux_scat_single! / update_flux_rad_single! on the global level, likewise
 - update_flux_scat_single! / update_flux_rad_single! on the sub-face level: self-heating inside
-  the roughness model, the external irradiation from the other global faces, and its absence
-  when the global self-heating is off
+  the roughness model, the directional irradiation from the other global faces (against an
+  independent reference implementation, on rough, flat and partly rough shapes), and its
+  absence when the global self-heating is off
 - update_temperature! on the global level, for all three solvers and for zero conductivity
 - update_temperature! on the sub-face level: the sub-faces advance, a near-flat roughness model
   reproduces the temperature of its parent face, and zero conductivity gives radiative
@@ -401,12 +402,58 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
         end
     end
 
+    # Reference implementation of the external irradiation of the sub-faces of global face `i`
+    # (sub-state `k`), written independently of the package: for every visible global face
+    # `j`, the emission of `j` towards `i` (directional for a rough `j`, Lambertian for a smooth
+    # one) times the view factor, distributed over the sub-faces of `i` that see `j`. The
+    # visibility is recomputed here with `update_illumination!`, so this also checks the
+    # precomputed masks. `emission(state_or_substate, n)` gives the emitted quantity per face.
+    function external_reference(state_hier, shape_hier, i, k, emission_global, emission_sub)
+        graph = shape_hier.face_visibility_graph
+        rs    = state_hier.roughness_states[k]
+        model = rs.problem.shape
+        ext   = zeros(length(model.faces))
+        seen  = Vector{Bool}(undef, length(model.faces))
+        total = 0.0     # Σ_j F_ij, the irradiance of the parent
+        power = 0.0     # power received by the sub-faces, as from a distant source of each F_ij
+        for (j, f, d̂) in zip(get_visible_face_indices(graph, i), get_view_factors(graph, i), get_visible_face_directions(graph, i))
+            k_j = state_hier.face_roughness_indices[j]
+            if k_j == 0
+                E = emission_global(j)
+            else
+                rs_j = state_hier.roughness_states[k_j]; model_j = rs_j.problem.shape
+                d̂_ji = transform_physical_vector_global_to_local(shape_hier, j, -d̂)
+                seen_j = Vector{Bool}(undef, length(model_j.faces))
+                update_illumination!(seen_j, model_j, d̂_ji; with_self_shadowing=true)
+                E = sum(max(0.0, model_j.face_normals[n] ⋅ d̂_ji) * model_j.face_areas[n] * emission_sub(rs_j, n)
+                        for n in eachindex(model_j.faces) if seen_j[n]; init=0.0) / (projected_area(model_j) * d̂_ji[3])
+            end
+            F = E * f
+            total += F
+            d̂_ij = transform_physical_vector_global_to_local(shape_hier, i, d̂)
+            update_illumination!(seen, model, d̂_ij; with_self_shadowing=true)
+            for m in eachindex(model.faces)
+                seen[m] || continue
+                c = model.face_normals[m] ⋅ d̂_ij
+                c > 0 || continue
+                ext[m] += F / d̂_ij[3] * c
+                power  += F / d̂_ij[3] * c * model.face_areas[m]
+            end
+        end
+        ext, total, power
+    end
+    ε_of(state) = state.problem.thermo_params.emissivity
+    emission_rad_global(state)  = j -> ε_of(state)[j] * AsteroidThermoPhysicalModels.σ_SB * state.temperature[begin, j]^4
+    emission_rad_sub            = (rs, n) -> ε_of(rs)[n] * AsteroidThermoPhysicalModels.σ_SB * rs.temperature[begin, n]^4
+    emission_scat_global(state) = j -> state.problem.thermo_params.reflectance_vis[j] * state.flux_sun[j]
+    emission_scat_sub           = (rs, n) -> rs.problem.thermo_params.reflectance_vis[n] * rs.flux_sun[n]
+
     @testset "update_flux_scat_single! / update_flux_rad_single! (sub-face level)" begin
         # Self-heating inside the roughness model must be exactly what a standalone state of
-        # the roughness model gives, and the flux the parent receives from the other global
-        # faces must be added on top, weighted by each sub-face's sky view factor. A concave
-        # global crater makes the parent fluxes non-zero; a roughness crater makes the
-        # intra-model exchange non-zero.
+        # the roughness model gives, and the radiation the other global faces send towards the
+        # sub-faces must be added on top — from the sub-faces of the neighbours' own roughness
+        # models, direction by direction. A concave global crater makes the neighbours' terms
+        # non-zero; a roughness crater makes the intra-model exchange non-zero.
         crater = create_shape_crater(0.4, 0.1; Nx=6, Ny=6)
         shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
         add_roughness_models!(shape_hier, crater)
@@ -417,6 +464,18 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
         # Self-heating inside the roughness model is always on
         @test all(rs.problem.with_self_heating for rs in state_hier.roughness_states)
         @test !isnothing(crater.face_visibility_graph)
+
+        # The pair visibility exists for every roughness state, with one mask per visible face
+        @test length(state_hier.roughness_neighbours) == length(state_hier.roughness_states)
+        for (i, k) in enumerate(state_hier.face_roughness_indices)
+            nb = state_hier.roughness_neighbours[k]
+            @test length(nb.visible) == n_visible_faces(shape_hier.face_visibility_graph, i)
+            @test all(length(v) == length(crater.faces) for v in nb.visible)
+            # Every neighbour carries roughness here, so every reverse position points back at i
+            for (p, j) in enumerate(get_visible_face_indices(shape_hier.face_visibility_graph, i))
+                @test get_visible_face_indices(shape_hier.face_visibility_graph, j)[nb.position_in_neighbour[p]] == i
+            end
+        end
 
         # Standalone state of the same roughness model, with the same flags as the sub-states
         problem_alone = SingleAsteroidThermoPhysicalProblem(crater, thermo_params, grid_params;
@@ -433,17 +492,11 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
         AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
         AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
 
-        # The parent fluxes are non-zero somewhere, so the external term is exercised
+        # The global fluxes are non-zero somewhere, so the shape really is concave
         @test any(>(0), state_hier.flux_scat)
         @test any(>(0), state_hier.flux_rad)
 
-        # Sky view factor of each sub-face of the (shared) roughness model
-        f_sky = [max(0.0, 1 - sum(get_view_factors(crater.face_visibility_graph, j)))
-                 for j in eachindex(crater.faces)]
-        @test all(0 .<= f_sky .<= 1)
-        @test any(<(1), f_sky)   # the crater walls do hide part of the sky
-
-        n_checked = 0
+        n_checked = n_irradiated = 0
         for (i, k) in enumerate(state_hier.face_roughness_indices)
             rs = state_hier.roughness_states[k]
             state_hier.illuminated_faces[i] || continue
@@ -456,17 +509,70 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
             AsteroidThermoPhysicalModels.update_flux_scat_single!(state_alone)
             AsteroidThermoPhysicalModels.update_flux_rad_single!(state_alone)
 
-            @test rs.flux_scat ≈ state_alone.flux_scat .+ f_sky .* state_hier.flux_scat[i]
-            @test rs.flux_rad  ≈ state_alone.flux_rad  .+ f_sky .* state_hier.flux_rad[i]
+            ext_rad,  total_rad,  power_rad  = external_reference(state_hier, shape_hier, i, k, emission_rad_global(state_hier),  emission_rad_sub)
+            ext_scat, total_scat, power_scat = external_reference(state_hier, shape_hier, i, k, emission_scat_global(state_hier), emission_scat_sub)
+            @test rs.flux_rad  ≈ state_alone.flux_rad  .+ ext_rad
+            @test rs.flux_scat ≈ state_alone.flux_scat .+ ext_scat
+
+            # Each neighbour irradiates the sub-faces like a distant source of irradiance F_ij
+            # (the same rule as the sunlight): the power received is F_ij / cos θ times the
+            # projected area of the sub-faces seen from that direction. This equals F_ij A_proj
+            # up to the shadowing discretisation of the sub-faces (a sub-face is seen or not
+            # from the ray through its centre), which is a few percent on this coarse crater.
+            model = rs.problem.shape
+            @test sum((rs.flux_rad .- state_alone.flux_rad) .* model.face_areas) ≈ power_rad
+            total_rad > 0 && (n_irradiated += 1)   # the flat rim of the global crater sees nothing
+
+            # ...and it is directional: the sub-faces that see no neighbour receive nothing,
+            # the others do, unlike an isotropic (sky-view-factor) distribution
+            seen_any = falses(length(model.faces))
+            for d̂ in get_visible_face_directions(shape_hier.face_visibility_graph, i)
+                d̂_ij = transform_physical_vector_global_to_local(shape_hier, i, d̂)
+                seen = Vector{Bool}(undef, length(model.faces))
+                update_illumination!(seen, model, d̂_ij; with_self_shadowing=true)
+                seen_any .|= seen .& (map(n̂ -> n̂ ⋅ d̂_ij, model.face_normals) .> 0)
+            end
+            @test all(iszero, ext_rad[.!seen_any])
+            @test all(>(0), ext_rad[seen_any])
         end
         @test n_checked > 0
+        @test n_irradiated > 0
+    end
+
+    @testset "external irradiation differs from an isotropic distribution on a deep crater" begin
+        # With a deep roughness crater, the walls facing a neighbour receive its radiation and the
+        # walls behind do not; distributing the same power by the sky view factor (the isotropic
+        # limit) gives a different pattern. On a flat model the two coincide (next testset).
+        crater = create_shape_crater(0.5, 0.3; Nx=6, Ny=6)
+        shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
+        add_roughness_models!(shape_hier, crater)
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier, 250.0)
+
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+        AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
+        AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
+
+        f_sky = [max(0.0, 1 - sum(get_view_factors(crater.face_visibility_graph, m))) for m in eachindex(crater.faces)]
+        n_differ = 0
+        for (i, k) in enumerate(state_hier.face_roughness_indices)
+            ext_rad, total_rad, _ = external_reference(state_hier, shape_hier, i, k, emission_rad_global(state_hier), emission_rad_sub)
+            total_rad > 0 || continue
+            isotropic = f_sky .* total_rad     # same power, spread as the sky-view-factor rule would
+            isapprox(ext_rad, isotropic; rtol=1e-3) || (n_differ += 1)
+        end
+        @test n_differ > 0
     end
 
     @testset "global self-heating off removes the external term only" begin
-        # With `with_self_heating = false` on the global problem, the parent fluxes are zero
-        # and the sub-faces receive nothing from outside — but the self-heating inside each
-        # roughness model is still computed. This is what makes an on/off comparison of the
-        # global self-heating isolate the external contribution.
+        # With `with_self_heating = false` on the global problem, no radiation is exchanged
+        # between global faces, no pair visibility is built, and the sub-faces receive nothing
+        # from outside — but the self-heating inside each roughness model is still computed.
+        # This is what makes an on/off comparison of the global self-heating isolate the
+        # external contribution.
         crater = create_shape_crater(0.4, 0.1; Nx=6, Ny=6)
         shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
         add_roughness_models!(shape_hier, crater)
@@ -474,6 +580,7 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
             with_self_shadowing=false, with_self_heating=false)
         state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
         AsteroidThermoPhysicalModels.init_temperature!(state_hier, 250.0)
+        @test isempty(state_hier.roughness_neighbours)
 
         problem_alone = SingleAsteroidThermoPhysicalProblem(crater, thermo_params, grid_params;
             with_self_shadowing=true, with_self_heating=true)
@@ -501,8 +608,10 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
     end
 
     @testset "near-flat roughness receives exactly the parent flux from outside" begin
-        # A flat roughness model has no walls (sky view factor 1) and no exchange between its
-        # own faces, so each sub-face must end up with exactly the parent's flux.
+        # A flat roughness model has no walls: every sub-face sees every neighbour with the
+        # inclination of the parent, and the neighbours (flat too) radiate as their smooth
+        # faces. The directional exchange therefore reduces to the smooth-surface flux of the
+        # parent face — the isotropic limit — and each sub-face must end up with exactly it.
         shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
         add_roughness_models!(shape_hier, create_shape_crater(0.4, 1e-6; Nx=4, Ny=4))
         problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
@@ -515,18 +624,74 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
         AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
         AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
 
-        # The view factors of a model flat to 1e-6 are ~1e-11 rather than zero, so the exchange
-        # between its own faces leaves a residual of ~1e-10 W/m². Compare with an absolute
-        # tolerance scaled by the largest parent flux: a relative one would fail on parents
-        # whose flux is exactly zero.
-        atol_scat = 1e-6 * maximum(state_hier.flux_scat)
-        atol_rad  = 1e-6 * maximum(state_hier.flux_rad)
+        # A model flat to 1e-6 is not exactly flat: the tilt of its normals (~1e-5) is felt
+        # for the neighbours seen at grazing angles (cos θ down to ~1e-3 on this crater), and
+        # the solar flux of its sub-faces differs from the parent's by ~1e-5 of the solar
+        # constant, which enters the reflected sunlight of the neighbours. Compare with an
+        # absolute tolerance scaled by the largest parent flux: a relative one would fail on
+        # parents whose flux is exactly zero.
+        atol_scat = 1e-4 * maximum(state_hier.flux_scat)
+        atol_rad  = 1e-4 * maximum(state_hier.flux_rad)
         @test atol_scat > 0 && atol_rad > 0
         for (i, k) in enumerate(state_hier.face_roughness_indices)
             rs = state_hier.roughness_states[k]
             @test all(isapprox.(rs.flux_scat, state_hier.flux_scat[i]; atol=atol_scat))
             @test all(isapprox.(rs.flux_rad,  state_hier.flux_rad[i];  atol=atol_rad))
         end
+    end
+
+    @testset "external irradiation with roughness on part of the faces" begin
+        # Neighbours without a roughness model radiate as smooth Lambertian faces; the rough
+        # faces among them radiate directionally. The reference implementation handles both.
+        crater = create_shape_crater(0.4, 0.1; Nx=6, Ny=6)
+        shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
+        rough_faces = 1:2:length(shape_hier.faces)
+        for i in rough_faces
+            add_roughness_models!(shape_hier, crater, i)
+        end
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+        n_faces = length(shape_hier.faces)
+        T₀ = repeat(reshape(range(200.0, 300.0; length=n_faces) |> collect, 1, n_faces), grid_params.n_depth)
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier, T₀)
+
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+        AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
+        AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
+
+        problem_alone = SingleAsteroidThermoPhysicalProblem(crater, thermo_params, grid_params;
+            with_self_shadowing=true, with_self_heating=true)
+        state_alone = AsteroidThermoPhysicalModels._build_single_state(problem_alone, CrankNicolson())
+
+        n_mixed = 0
+        for (i, k) in enumerate(state_hier.face_roughness_indices)
+            k == 0 && continue
+            rs = state_hier.roughness_states[k]
+            nb = state_hier.roughness_neighbours[k]
+            js = get_visible_face_indices(shape_hier.face_visibility_graph, i)
+            any(j -> state_hier.face_roughness_indices[j] == 0, js) && any(j -> state_hier.face_roughness_indices[j] != 0, js) && (n_mixed += 1)
+            # Reverse positions: 0 for smooth neighbours, the position of i otherwise
+            for (p, j) in enumerate(js)
+                if state_hier.face_roughness_indices[j] == 0
+                    @test nb.position_in_neighbour[p] == 0
+                else
+                    @test get_visible_face_indices(shape_hier.face_visibility_graph, j)[nb.position_in_neighbour[p]] == i
+                end
+            end
+
+            AsteroidThermoPhysicalModels.init_temperature!(state_alone, T₀[begin, i])
+            AsteroidThermoPhysicalModels.update_flux_sun!(state_alone, transform_physical_vector_global_to_local(shape_hier, i, r☉))
+            AsteroidThermoPhysicalModels.update_flux_scat_single!(state_alone)
+            AsteroidThermoPhysicalModels.update_flux_rad_single!(state_alone)
+            ext_rad, _, _  = external_reference(state_hier, shape_hier, i, k, emission_rad_global(state_hier),  emission_rad_sub)
+            ext_scat, _, _ = external_reference(state_hier, shape_hier, i, k, emission_scat_global(state_hier), emission_scat_sub)
+            @test rs.flux_rad  ≈ state_alone.flux_rad  .+ ext_rad
+            @test rs.flux_scat ≈ state_alone.flux_scat .+ ext_scat
+            @test all(isfinite, rs.flux_rad)
+        end
+        @test n_mixed > 0
     end
 
     @testset "self-heating disabled leaves the global fluxes at zero" begin

--- a/test/test_roughness_state.jl
+++ b/test/test_roughness_state.jl
@@ -471,9 +471,9 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
             nb = state_hier.roughness_neighbours[k]
             @test length(nb.visible_sub_faces) == n_visible_faces(shape_hier.face_visibility_graph, i)
             @test all(length(v) == length(crater.faces) for v in nb.visible_sub_faces)
-            # Every neighbour carries roughness here, so every reverse position points back at i
+            # Every neighbour carries roughness here, so every reverse index points back at i
             for (p, j) in enumerate(get_visible_face_indices(shape_hier.face_visibility_graph, i))
-                @test get_visible_face_indices(shape_hier.face_visibility_graph, j)[nb.position_in_neighbour[p]] == i
+                @test get_visible_face_indices(shape_hier.face_visibility_graph, j)[nb.index_in_neighbour[p]] == i
             end
         end
 
@@ -675,9 +675,9 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
             # Reverse positions: 0 for smooth neighbours, the position of i otherwise
             for (p, j) in enumerate(js)
                 if state_hier.face_roughness_indices[j] == 0
-                    @test nb.position_in_neighbour[p] == 0
+                    @test nb.index_in_neighbour[p] == 0
                 else
-                    @test get_visible_face_indices(shape_hier.face_visibility_graph, j)[nb.position_in_neighbour[p]] == i
+                    @test get_visible_face_indices(shape_hier.face_visibility_graph, j)[nb.index_in_neighbour[p]] == i
                 end
             end
 

--- a/test/test_roughness_state.jl
+++ b/test/test_roughness_state.jl
@@ -694,6 +694,76 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
         @test n_mixed > 0
     end
 
+    @testset "external irradiation with heterogeneous roughness models, scales and rotations" begin
+        # Every face may carry its own roughness model, scale and orientation. The masks are
+        # built per face from that face's own patch and transform, and the emitter side reads
+        # the neighbour's own patch and mask, so models with different numbers of sub-faces,
+        # different scales and rotated local frames must all agree with the reference
+        # implementation (which uses the same per-face transforms).
+        crater_a = create_shape_crater(0.4, 0.1; Nx=4, Ny=4)
+        crater_b = create_shape_crater(0.3, 0.2; xc=0.3, yc=0.6, Nx=6, Ny=6)   # off-centre: not symmetric under rotation
+        shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
+        n_faces = length(shape_hier.faces)
+        R_z(ϕ) = SMatrix{3, 3}(cos(ϕ), sin(ϕ), 0, -sin(ϕ), cos(ϕ), 0, 0, 0, 1)
+        for i in 1:n_faces
+            if isodd(i)
+                add_roughness_models!(shape_hier, crater_a, i)
+            else
+                # crater_b at half scale, with its local frame rotated by 60° about the face normal
+                scale = 0.5
+                t = AsteroidShapeModels.compute_face_roughness_transform(shape_hier, i; scale)
+                t_rot = AsteroidShapeModels.AffineMap(R_z(π/3) * t.linear, R_z(π/3) * t.translation)
+                add_roughness_models!(shape_hier, crater_b, i; scale, transform=t_rot)
+            end
+        end
+        @test get_roughness_model_scale(shape_hier, 2) ≈ 0.5
+        @test get_roughness_model_scale(shape_hier, 1) ≈ 1.0
+        # The rotation really is applied: the local x axis of face 2 differs from the default one
+        t_default = AsteroidShapeModels.compute_face_roughness_transform(shape_hier, 2; scale=0.5)
+        ê_x_default = (t_default.linear * 0.5)' * SVector(1.0, 0.0, 0.0)
+        ê_x_rotated = transform_physical_vector_local_to_global(shape_hier, 2, SVector(1.0, 0.0, 0.0))
+        @test ê_x_default ⋅ ê_x_rotated ≈ cos(π/3)
+
+        problem_hier = SingleAsteroidThermoPhysicalProblem(shape_hier, thermo_params, grid_params;
+            with_self_shadowing=false, with_self_heating=true)
+        state_hier = AsteroidThermoPhysicalModels._build_single_state(problem_hier, CrankNicolson())
+        T₀ = repeat(reshape(range(200.0, 300.0; length=n_faces) |> collect, 1, n_faces), grid_params.n_depth)
+        AsteroidThermoPhysicalModels.init_temperature!(state_hier, T₀)
+
+        r☉ = SVector(0.2, -0.1, 1.0) * AsteroidThermoPhysicalModels.au2m
+        AsteroidThermoPhysicalModels.update_flux_sun!(state_hier, r☉)
+        AsteroidThermoPhysicalModels.update_flux_scat_single!(state_hier)
+        AsteroidThermoPhysicalModels.update_flux_rad_single!(state_hier)
+
+        # One standalone state per roughness model, for the intra-patch part
+        alone = Dict(patch => AsteroidThermoPhysicalModels._build_single_state(
+                SingleAsteroidThermoPhysicalProblem(patch, thermo_params, grid_params;
+                    with_self_shadowing=true, with_self_heating=true), CrankNicolson())
+            for patch in (crater_a, crater_b))
+
+        n_checked = 0
+        for (i, k) in enumerate(state_hier.face_roughness_indices)
+            rs = state_hier.roughness_states[k]
+            nb = state_hier.roughness_neighbours[k]
+            patch = rs.problem.shape
+            @test patch === (isodd(i) ? crater_a : crater_b)
+            @test all(length(v) == length(patch.faces) for v in nb.visible_sub_faces)
+
+            state_alone = alone[patch]
+            AsteroidThermoPhysicalModels.init_temperature!(state_alone, T₀[begin, i])
+            AsteroidThermoPhysicalModels.update_flux_sun!(state_alone, transform_physical_vector_global_to_local(shape_hier, i, r☉))
+            AsteroidThermoPhysicalModels.update_flux_scat_single!(state_alone)
+            AsteroidThermoPhysicalModels.update_flux_rad_single!(state_alone)
+            ext_rad, total_rad, _ = external_reference(state_hier, shape_hier, i, k, emission_rad_global(state_hier),  emission_rad_sub)
+            ext_scat, _, _        = external_reference(state_hier, shape_hier, i, k, emission_scat_global(state_hier), emission_scat_sub)
+            @test rs.flux_rad  ≈ state_alone.flux_rad  .+ ext_rad
+            @test rs.flux_scat ≈ state_alone.flux_scat .+ ext_scat
+            @test all(isfinite, rs.flux_rad)
+            total_rad > 0 && (n_checked += 1)
+        end
+        @test n_checked > 0
+    end
+
     @testset "self-heating disabled leaves the global fluxes at zero" begin
         shape_hier = create_shape_crater(0.4, 0.1; Nx=8, Ny=8)
         add_roughness_models!(shape_hier, create_shape_crater(0.4, 0.1; Nx=4, Ny=4))

--- a/test/test_roughness_state.jl
+++ b/test/test_roughness_state.jl
@@ -469,8 +469,8 @@ Unit tests for SingleAsteroidThermoPhysicalState on a shape with surface roughne
         @test length(state_hier.roughness_neighbours) == length(state_hier.roughness_states)
         for (i, k) in enumerate(state_hier.face_roughness_indices)
             nb = state_hier.roughness_neighbours[k]
-            @test length(nb.visible) == n_visible_faces(shape_hier.face_visibility_graph, i)
-            @test all(length(v) == length(crater.faces) for v in nb.visible)
+            @test length(nb.visible_sub_faces) == n_visible_faces(shape_hier.face_visibility_graph, i)
+            @test all(length(v) == length(crater.faces) for v in nb.visible_sub_faces)
             # Every neighbour carries roughness here, so every reverse position points back at i
             for (p, j) in enumerate(get_visible_face_indices(shape_hier.face_visibility_graph, i))
                 @test get_visible_face_indices(shape_hier.face_visibility_graph, j)[nb.position_in_neighbour[p]] == i


### PR DESCRIPTION
## Summary

Replaces the isotropic external irradiation of the roughness sub-facets (v0.3.0, #229: parent smooth-surface flux × sky view factor) by a **directional** exchange between the roughness models of the visible global faces.

For every face `j` visible from a rough face `i`:

1. **Emitter** — the emission of `j` towards `i`: `E_j(d̂_ji) = Σ_n V_n (n̂_n·d̂_ji)⁺ E_n a_n / (A_proj cos θ_ji)` over the sub-facets of `j`'s own roughness model that face `i` (thermal-infrared beaming: a hot sunlit wall facing `i` radiates more than the smooth face would). A smooth `j` radiates as a Lambertian face.
2. **Far field** — `F_ij = E_j f_ij`, the same form as the smooth-surface term.
3. **Receiver** — `F_ij` is distributed over the sub-facets of `i` that see `j`, each by its inclination, like a distant source (the same rule as the sunlight).

The sub-facet visibilities of every visible pair are precomputed once when the state is built (`RoughnessNeighbours`: one `BitVector` per visible face plus the reverse position in the neighbour's adjacency list). Directions are rotated on the fly; no direction tables. Reflected sunlight is single-scattered, so nothing depends on the order in which the roughness models are updated. The global-level fluxes are untouched.

There is no switch: `with_self_heating = false` gives no external term (and no masks), `true` gives the directional exchange. `_add_external_irradiance!` is removed; `roughness_radiance` is rewritten on the shared `_directional_emission` helper (no behaviour change).

**Results change** for runs with roughness and `with_self_heating = true` on concave shapes (convex shapes and flat roughness models are unchanged). Cost: proportional to the number of visible pairs of rough facets times the number of sub-facets — about 15 µs per pair and time step for a 1000-sub-facet model, and 0.5 ms per pair for the precomputation of the masks. A few percent of a step on a mostly convex body, where only a few facets see each other; on a strongly concave one (2048 facets seeing 560 others each) it dominates the step (16 s) and the precomputation takes 9 min.

## Commits

- `feat: precompute the pair visibility of roughness sub-facets` — `RoughnessNeighbours`, `_build_roughness_neighbours`, `_directional_emission`
- `feat!: directional external irradiation of the roughness sub-facets` — `_add_external_radiation!` / `_add_external_scattering!`, `_distribute_directional!`, tests
- `docs: describe the directional irradiation of roughness models` — `physical_model.md`, CHANGELOG

## Tests

- `test_roughness_state.jl`: an independent reference implementation (calling `update_illumination!` on the spot) reproduces the sub-facet fluxes on rough, flat and partly rough shapes; the power received matches that of a distant source; sub-facets that see no neighbour receive nothing; the pattern differs from the isotropic distribution on a deep crater; `with_self_heating = false` builds no masks and adds nothing; a flat roughness model receives exactly the parent flux (the v0.3.0 identity); reverse positions are consistent (0 for smooth neighbours).
- `test_roughness_solve.jl`: energy balance of `solve` on a concave global shape with roughness.
- Full `Pkg.test()` passes locally.

Not included: grazing-angle treatment and the fractal-patch quantification (separate items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

